### PR TITLE
Clarify cleanup filepath

### DIFF
--- a/nvidia/txt2kg/README.md
+++ b/nvidia/txt2kg/README.md
@@ -130,6 +130,9 @@ You can also access individual services:
 Stop all services and optionally remove containers:
 
 ```bash
+## Change to deployment directory
+cd ./nvidia/txt2kg/assets/deploy/compose
+
 ## Stop services
 docker compose down
 


### PR DESCRIPTION
Specify location to docker-compose directory relative to project root
--

On first attempt at cleaning up this (awesome) demo, I ran these commands in the last place the `README` specified:
```bash
git clone https://github.com/NVIDIA/dgx-spark-playbooks
cd nvidia/txt2kg/assets
```
And I was met with a lovely:
```bash
comjf@spark-01:~/Programming/comjf/dgx-spark-playbooks/nvidia/txt2kg/assets$ docker compose down
no configuration file provided: not found
```

Didn't take me long to figure out I should be in `./deploy/compose` -- however, I propose the project use the entire relative path back to the repo root.