### PR TITLE
Unsloth Playbook fixed and tested

### DIFF
--- a/nvidia/unsloth/README.md
+++ b/nvidia/unsloth/README.md
@@ -137,6 +137,8 @@ per_device_train_batch_size = 4
 max_steps = 1000
 ```
 
+When you exit the container, the fine-tuned unsloth ouputs will be in the "ouputs" directory.
+
 Visit https://github.com/unslothai/unsloth/wiki
 for advanced usage instructions, including:
 - [Saving models in GGUF format for vLLM](https://github.com/unslothai/unsloth/wiki#saving-to-gguf)


### PR DESCRIPTION
When attempting to follow the DGX Spark [unsloth playbook](https://github.com/NVIDIA/dgx-spark-playbooks/tree/main/nvidia/unsloth) I ran into an error some dependency issues. This PR addresses all these issues and was tested and found to work correctly now on my DGX Spark. Here's a description of the changes:

[Step 6](https://github.com/NVIDIA/dgx-spark-playbooks/tree/main/nvidia/unsloth#step-6-create-python-test-script), has the wrong url to use with curl, it will download a html github page of the script, not the raw contents of the script:

**Wrong**: 
```
curl -O https://github.com/NVIDIA/dgx-spark-playbooks/blob/main/nvidia/unsloth/assets/test_unsloth.py
```

**Correct**: 
```
curl -O https://raw.githubusercontent.com/NVIDIA/dgx-spark-playbooks/refs/heads/main/nvidia/unsloth/assets/test_unsloth.py
```

Then when trying to execute the test_unsloth.py script unsloth had an error indicating that it needed a different version of the 'trl' library.

After that was fixed, the script now progressed further but enountered another error when it lacked the 'hf_transfer' package required to download models from huggingface.

Also, with the original docker command, the user will lose their fine-tuned model ouputs when they exit the container. I've updated the command to map the local 'outputs' directory, to the 'workspace/outputs' directory in the container so the user doesn't lose their work.

The playbook changes provided by this PR have been tested on DGX Spark and the unsloth playbook now works correctly.
