### PR TITLE
update instructions for unsloth training

### DIFF
--- a/nvidia/unsloth/README.md
+++ b/nvidia/unsloth/README.md
@@ -89,9 +89,10 @@ pip install transformers peft datasets "trl==0.19.1"
 pip install --no-deps unsloth unsloth_zoo
 ```
 
-## Step 5. Build and install bitsandbytes inside Docker
+## Step 5. Build and install bitsandbytes and hf_transfer inside Docker
 ```bash
 pip install --no-deps bitsandbytes
+pip install hf_transfer
 ```
 
 ## Step 6. Create Python test script


### PR DESCRIPTION
The README is missing a python package which causes the following issue when running `test_unsloth.py` 

```
root@f6861e54e0b3:/workspace/dgx-spark-playbooks/nvidia/unsloth/assets# python test_unsloth.py
/usr/local/lib/python3.12/dist-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you
did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]
🦥 Unsloth: Will patch your computer to enable 2x faster free finetuning.
🦥 Unsloth Zoo will now patch everything to make training faster!
Traceback (most recent call last):
  File "/workspace/dgx-spark-playbooks/nvidia/unsloth/assets/test_unsloth.py", line 48, in <module>
    model, tokenizer = FastModel.from_pretrained(
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/unsloth/models/loader.py", line 731, in from_pretrained
    model_types = get_transformers_model_type(
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/unsloth_zoo/hf_utils.py", line 112, in get_transformers_model_type
    raise RuntimeError(
RuntimeError: Unsloth: No config file found - are you sure the `model_name` is correct?
If you're using a model on your local device, confirm if the folder location exists.
If you're using a HuggingFace online model, check if it exists.
```

This is resolved by installing `hf_transfer` package.