### PR TITLE
A minor fix of Nemotron-3-Nano playbook using llama.cpp with Flash Attention

### DIFF
--- a/nvidia/nemotron/README.md
+++ b/nvidia/nemotron/README.md
@@ -101,7 +101,7 @@ Build llama.cpp with CUDA enabled and targeting the GB10's sm_121 compute archit
 
 ```bash
 mkdir build && cd build
-cmake .. -DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES="121" -DLLAMA_CURL=OFF
+cmake .. -DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES="121" -DLLAMA_CURL=OFF -DGGML_CUDA_FA_ALL_QUANTS=ON 
 make -j8
 ```
 
@@ -128,6 +128,7 @@ Launch the inference server with the Nemotron model. The server provides an Open
   --model ~/models/nemotron3-gguf/Nemotron-3-Nano-30B-A3B-UD-Q8_K_XL.gguf \
   --host 0.0.0.0 \
   --port 30000 \
+  --flash-attn 1 \
   --n-gpu-layers 99 \
   --ctx-size 8192 \
   --threads 8
@@ -136,6 +137,7 @@ Launch the inference server with the Nemotron model. The server provides an Open
 **Parameter explanation:**
 - `--host 0.0.0.0`: Listen on all network interfaces
 - `--port 30000`: API server port
+- `--flash-attn 1`: Enables Flash Attention
 - `--n-gpu-layers 99`: Offload all layers to GPU
 - `--ctx-size 8192`: Context window size (can increase up to 1M)
 - `--threads 8`: CPU threads for non-GPU operations


### PR DESCRIPTION
Hello,

This PR includes build instructions for enabling Flash Attention(FA) (-DGGML_CUDA_FA_ALL_QUANTS=ON) to optimize performance on Blackwell (GB10) GPUs.  By default, llama.cpp only compiles FA kernels for the most common quantization types (like f16 and q8_0 KV cache) to keep the library size small and compilation fast.

**Benchmark results** 
Tests were performed on NVIDIA DGX Spark (GB10) using Nemotron-Nano-3-30B-A3B-Q4_K_M.gguf

- with FA enabled

```
./bin/llama-bench -m /home/spark/.cache/llama.cpp/ggml-org_Nemotron-Nano-3-30B-A3B-GGUF_Nemotron-Nano-3-30B-A3B-Q4_K_M.gguf \
  -fa 1 \
  -ngl 99 \
  -p 16384 \
  -n 128
ggml_cuda_init: found 1 CUDA devices:
  Device 0: NVIDIA GB10, compute capability 12.1, VMM: yes
| model                          |       size |     params | backend    | ngl | fa |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | -: | --------------: | -------------------: |
| nemotron_h_moe 31B.A3.5B Q4_K - Medium |  22.82 GiB |    31.58 B | CUDA       |  99 |  1 |         pp16384 |       2189.66 ± 2.53 |
| nemotron_h_moe 31B.A3.5B Q4_K - Medium |  22.82 GiB |    31.58 B | CUDA       |  99 |  1 |           tg128 |         63.13 ± 0.05 |

build: 193ee38a1 (7653)
```

- with FA disabled
```

Also double-checked using [vllm bench serve](https://docs.vllm.ai/en/latest/cli/bench/serve/)
./bin/llama-bench -m /home/spark/.cache/llama.cpp/ggml-org_Nemotron-Nano-3-30B-A3B-GGUF_Nemotron-Nano-3-30B-A3B-Q4_K_M.gguf \
  -fa 0 \
  -ngl 99 \
  -p 16384 \
  -n 128
ggml_cuda_init: found 1 CUDA devices:
  Device 0: NVIDIA GB10, compute capability 12.1, VMM: yes
| model                          |       size |     params | backend    | ngl |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | --------------: | -------------------: |
| nemotron_h_moe 31B.A3.5B Q4_K - Medium |  22.82 GiB |    31.58 B | CUDA       |  99 |         pp16384 |       1538.34 ± 2.69 |
| nemotron_h_moe 31B.A3.5B Q4_K - Medium |  22.82 GiB |    31.58 B | CUDA       |  99 |           tg128 |         62.65 ± 0.05 |

build: 193ee38a1 (7653)
```

Also, it was double-checked using [vllm bench serve](https://docs.vllm.ai/en/latest/cli/bench/serve/) 

```
with FA enabled:

./bin/llama-server \
  -hf ggml-org/Nemotron-Nano-3-30B-A3B-GGUF \
  -fa 1 \
  -ngl 99 \
  --jinja \
  -c 20000 \
  --no-mmap \
  --host 0.0.0.0 \
  --port 8080

============ Serving Benchmark Result ============
Successful requests:                     5         
Failed requests:                         0         
Maximum request concurrency:             1         
Benchmark duration (s):                  39.74     
Total input tokens:                      81920     
Total generated tokens:                  422       
Request throughput (req/s):              0.13      
Output token throughput (tok/s):         10.62     
Peak output token throughput (tok/s):    74.00     
Peak concurrent requests:                2.00      
Total token throughput (tok/s):          2071.85   
---------------Time to First Token----------------
Mean TTFT (ms):                          6801.24   
Median TTFT (ms):                        8386.11   
P99 TTFT (ms):                           8568.61   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          14.24     
Median TPOT (ms):                        13.78     
P99 TPOT (ms):                           15.80     
---------------Inter-token Latency----------------
Mean ITL (ms):                           13.53     
Median ITL (ms):                         13.60     
P99 ITL (ms):                            15.91     
==================================================

with FA disabled:

./bin/llama-server \
  -hf ggml-org/Nemotron-Nano-3-30B-A3B-GGUF \
  -fa 0 \
  -ngl 99 \
  --jinja \
  -c 20000 \
  --no-mmap \
  --host 0.0.0.0 \
  --port 8080

============ Serving Benchmark Result ============
Successful requests:                     5         
Failed requests:                         0         
Maximum request concurrency:             1         
Benchmark duration (s):                  68.54     
Total input tokens:                      81920     
Total generated tokens:                  418       
Request throughput (req/s):              0.07      
Output token throughput (tok/s):         6.10      
Peak output token throughput (tok/s):    68.00     
Peak concurrent requests:                2.00      
Total token throughput (tok/s):          1201.36   
---------------Time to First Token----------------
Mean TTFT (ms):                          12476.12  
Median TTFT (ms):                        15431.61  
P99 TTFT (ms):                           15952.79  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          15.70     
Median TPOT (ms):                        14.87     
P99 TPOT (ms):                           18.46     
---------------Inter-token Latency----------------
Mean ITL (ms):                           14.66     
Median ITL (ms):                         14.74     
P99 ITL (ms):                            17.13     
==================================================
```
