### PR TITLE
fix(txt2kg): prevent Ollama restart loop and large-model load timeout

### DIFF
--- a/nvidia/txt2kg/assets/deploy/compose/docker-compose.yml
+++ b/nvidia/txt2kg/assets/deploy/compose/docker-compose.yml
@@ -109,6 +109,9 @@ services:
       - OLLAMA_KV_CACHE_TYPE=q8_0
       - OLLAMA_GPU_LAYERS=-1
       - OLLAMA_LLM_LIBRARY=cuda_v13
+      # Cold-loading an 80+ GiB model into the GB10 CUDA buffer exceeds the
+      # default 5m startup budget; Ollama would kill the runner mid-load.
+      - OLLAMA_LOAD_TIMEOUT=20m
     networks:
       - default
     restart: unless-stopped

--- a/nvidia/txt2kg/assets/deploy/services/ollama/entrypoint.sh
+++ b/nvidia/txt2kg/assets/deploy/services/ollama/entrypoint.sh
@@ -45,8 +45,14 @@ echo "Checking for existing models..."
 
 if ! /bin/ollama list | grep -q llama3.1:8b; then
     echo "No models found. Pulling llama3.1:8b..."
-    /bin/ollama pull llama3.1:8b
-    echo "Successfully pulled llama3.1:8b"
+    # A failed pull (no network, registry down) must not kill PID 1 — that would
+    # trap the container in a restart loop instead of leaving a usable server.
+    if /bin/ollama pull llama3.1:8b; then
+        echo "Successfully pulled llama3.1:8b"
+    else
+        echo "WARNING: pull failed. Server stays up; retry with:"
+        echo "  docker exec ollama-compose ollama pull llama3.1:8b"
+    fi
 else
     echo "Models already exist, skipping pull."
 fi


### PR DESCRIPTION
## Summary

Two fixes to the txt2kg default (ArangoDB + Ollama) stack that prevent the Ollama container from becoming stuck or unusable. Both were hit while bringing the default stack up on a DGX Spark (GB10).

## 1. Ollama container crash-loops on a failed model pull

`deploy/services/ollama/entrypoint.sh` runs under `set -e` and pulls the model as PID 1. If the boot-time `ollama pull` fails for any transient reason (registry unreachable, DNS hiccup), PID 1 exits non-zero, and with `restart: unless-stopped` the container enters an infinite restart loop — the server never stays up long enough to pull the model manually.

**Fix:** treat the boot-time pull as best-effort. On failure, log a retry hint and leave the server running instead of killing PID 1.

## 2. Large models exceed the default startup timeout

Cold-loading a large model into the GB10 CUDA buffer can take several minutes. Ollama's default `OLLAMA_LOAD_TIMEOUT` is 5m, after which it kills the runner mid-load ("timed out waiting for llama-server to start") and unloads the model — even when the model fits in GPU memory. On this hardware a large model measured ~7m to become ready.

**Fix:** set `OLLAMA_LOAD_TIMEOUT=20m` in the Ollama service env in `deploy/compose/docker-compose.yml`.

## Scope

- No change to the default model (`llama3.1:8b`) or any other defaults.
- `entrypoint.sh`: pull becomes non-fatal.
- `docker-compose.yml`: one env var added.

## Test

- Reproduced the restart loop via a failed boot pull; with the fix the server stays up and `ollama pull` succeeds manually.
- Verified a large model that previously hit the 5m timeout loads cleanly with the 20m budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
