### PR TITLE
Harden the Qwen3.6 agent recipe against tool-call regressions

### DIFF
--- a/nvidia/vllm/README.md
+++ b/nvidia/vllm/README.md
@@ -714,8 +714,13 @@ newgrp docker
 ## Step 2. Pull vLLM container image
 
 ```bash
-docker pull vllm/vllm-openai:latest
+export VLLM_QWEN_IMAGE="vllm/vllm-openai:v0.26.0"
+docker pull "$VLLM_QWEN_IMAGE"
 ```
+
+This recipe requires vLLM 0.26.0 or later. Earlier releases can produce missing
+or duplicate tool calls when MTP speculative decoding and prefix caching are
+used together with Qwen3.6's hybrid attention layers.
 
 ## Step 3. Launch the Agent Ready Qwen3.6 35B server
 
@@ -728,10 +733,10 @@ Launch the container and start the vLLM server with the agent-ready
 ## Get a token from https://huggingface.co/settings/tokens
 export HF_TOKEN="your_huggingface_token"
 
-docker run -it --gpus all -p 8000:8000 \
+docker run -it --gpus all -p 8000:8000 --name qwen36-vllm \
   -e HF_TOKEN="$HF_TOKEN" \
   -v ~/.cache/huggingface:/root/.cache/huggingface \
-  vllm/vllm-openai:latest \
+  "$VLLM_QWEN_IMAGE" \
   nvidia/Qwen3.6-35B-A3B-NVFP4 \
   --host 0.0.0.0 \
   --port 8000 \
@@ -773,14 +778,24 @@ curl http://localhost:8000/v1/chat/completions \
 
 Expected response should contain `"content": "204"` or similar mathematical calculation.
 
+The single request above checks connectivity. Before connecting an agent, run
+the multi-step tool-call check from the repository root:
+
+```bash
+python3 nvidia/vllm/assets/verify_qwen36_tools.py
+```
+
+The check makes 120 tool calls across ten repeated conversations and exits on a
+missing, duplicate, or malformed call. A successful run ends with `PASS: 120
+tool calls`.
 
 ## Step 4. Cleanup and rollback
 
 For container approach (non-destructive):
 
 ```bash
-docker rm $(docker ps -aq --filter ancestor=vllm/vllm-openai:latest)
-docker rmi vllm/vllm-openai:latest
+docker rm -f qwen36-vllm
+docker rmi "$VLLM_QWEN_IMAGE"
 ```
 
 ## Troubleshooting
@@ -793,6 +808,7 @@ docker rmi vllm/vllm-openai:latest
 | Container registry authentication fails | Invalid or expired GitLab token | Generate new auth token |
 | SM_121a architecture not recognized | Missing LLVM patches | Verify SM_121a patches applied to LLVM source |
 | CUDA out of memory | Insufficient GPU memory | Reduce --max-model-len and --max-num-seqs parameters |
+| Qwen3.6 returns missing, duplicate, or raw XML tool calls | vLLM older than 0.26.0 with MTP and prefix caching | Use the pinned image above. If an older image is required, remove `--speculative-config` and rerun the multi-step check |
 
 ## Common Issues for running on two Sparks
 | Symptom | Cause | Fix |

--- a/nvidia/vllm/assets/verify_qwen36_tools.py
+++ b/nvidia/vllm/assets/verify_qwen36_tools.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Exercise Qwen3.6 tool calling across repeated multi-step conversations."""
+
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+
+
+DEFAULT_MODEL = "nvidia/Qwen3.6-35B-A3B-NVFP4"
+METRIC_ORDER = (45, 0, 23, 12, 44, 1, 31, 7, 39, 15, 22, 45)
+
+
+def make_tools():
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": f"lookup_metric_{number:02d}",
+                "description": (
+                    f"Return metric number {number} for a city. "
+                    f"Use only when metric {number} is requested."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            },
+        }
+        for number in range(46)
+    ]
+
+
+def post_json(url, payload, timeout):
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    started = time.perf_counter()
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return json.load(response), time.perf_counter() - started
+
+
+def validate(choice, expected):
+    message = choice.get("message") or {}
+    tool_calls = message.get("tool_calls") or []
+    content = message.get("content") or ""
+
+    if choice.get("finish_reason") != "tool_calls":
+        return False, f"finish_reason={choice.get('finish_reason')!r}"
+    if len(tool_calls) != 1:
+        return False, f"expected one tool call, received {len(tool_calls)}"
+
+    function = tool_calls[0].get("function") or {}
+    if function.get("name") != expected:
+        return False, f"expected {expected}, received {function.get('name')!r}"
+
+    try:
+        arguments = json.loads(function.get("arguments", ""))
+    except (TypeError, json.JSONDecodeError) as error:
+        return False, f"invalid tool arguments: {error}"
+    if arguments != {"city": "Seoul"}:
+        return False, f"unexpected tool arguments: {arguments!r}"
+
+    if "<tool_call>" in content or "<function=" in content:
+        return False, "raw tool markup leaked into response content"
+    return True, ""
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Check for missing, duplicated, or malformed tool calls while "
+            "prefix caching and MTP are active."
+        )
+    )
+    parser.add_argument("--base-url", default="http://localhost:8000")
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--sessions", type=int, default=10)
+    parser.add_argument("--timeout", type=float, default=120)
+    args = parser.parse_args()
+    if args.sessions < 1:
+        parser.error("--sessions must be at least 1")
+
+    endpoint = f"{args.base_url.rstrip('/')}/v1/chat/completions"
+    tools = make_tools()
+    calls = 0
+    latencies = []
+
+    for session in range(args.sessions):
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "You are testing a tool API. When the user names a tool, "
+                    "call exactly that tool with city Seoul. Never answer "
+                    "directly."
+                ),
+            }
+        ]
+
+        for turn, metric in enumerate(METRIC_ORDER):
+            expected = f"lookup_metric_{metric:02d}"
+            messages.append(
+                {
+                    "role": "user",
+                    "content": (
+                        f"Turn {turn}: call {expected} for Seoul. "
+                        "Use the requested tool now and do not answer directly."
+                    ),
+                }
+            )
+            payload = {
+                "model": args.model,
+                "messages": messages,
+                "tools": tools,
+                "temperature": 0,
+                "seed": 0,
+                "max_tokens": 1024,
+            }
+
+            try:
+                result, latency = post_json(endpoint, payload, args.timeout)
+            except (urllib.error.URLError, TimeoutError) as error:
+                print(
+                    f"FAIL session={session + 1} turn={turn + 1}: {error}",
+                    file=sys.stderr,
+                )
+                return 1
+
+            calls += 1
+            latencies.append(latency)
+            choice = result["choices"][0]
+            valid, reason = validate(choice, expected)
+            if not valid:
+                print(
+                    f"FAIL session={session + 1} turn={turn + 1}: {reason}",
+                    file=sys.stderr,
+                )
+                print(json.dumps(choice, indent=2), file=sys.stderr)
+                return 1
+
+            tool_call = json.loads(
+                json.dumps(choice["message"]["tool_calls"][0])
+            )
+            tool_call["id"] = f"call_{turn:02d}"
+            messages.extend(
+                [
+                    {
+                        "role": "assistant",
+                        "content": choice["message"].get("content"),
+                        "tool_calls": [tool_call],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": tool_call["id"],
+                        "name": expected,
+                        "content": json.dumps(
+                            {
+                                "metric": metric,
+                                "city": "Seoul",
+                                "value": metric * 10,
+                            }
+                        ),
+                    },
+                ]
+            )
+
+        print(f"session {session + 1}/{args.sessions}: pass", flush=True)
+
+    print(
+        f"PASS: {calls} tool calls; "
+        f"mean latency {sum(latencies) / len(latencies):.2f}s; "
+        f"max latency {max(latencies):.2f}s"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- Pin the agent-ready Qwen3.6 recipe to `vllm/vllm-openai:v0.26.0` instead of the moving `latest` tag.
- Add a standard-library-only verifier that exercises 46 tools over repeated 12-step conversations and rejects missing, duplicated, malformed, or raw-XML tool calls.
- Document the older-vLLM fallback: remove MTP while retaining prefix caching.
- Give the container a stable name so cleanup targets only this recipe's container.

## Why

This addresses the failure mode reported in #89. Older vLLM builds can corrupt tool-call output when MTP speculative decoding and prefix caching are combined with Qwen3.6's hybrid attention state. A one-shot arithmetic request only verifies connectivity and does not exercise that path.

I reproduced an intermittent duplicate call on a single DGX Spark with vLLM 0.24.0: a deterministic multi-step run expected one `lookup_metric_23` call and received two identical calls. The same 0.24.0 configuration without MTP completed 120/120 calls.

The submitted verifier completed 120/120 calls with the pinned v0.26.0 image. During that run, server metrics recorded 83,616 prefix-cache hit tokens and 9,495 speculative draft tokens (8,237 accepted), confirming that both features were active. Because the older-build failure is intermittent, this verifier is a regression smoke test rather than a proof that any single passing server is safe.

Tested image:

```text
vllm/vllm-openai:v0.26.0
sha256:ffb2d59b1c059a5bd8d781320c9f5189de8293693b7d95da54befddaa54abf52
```

## Validation

```text
git diff --check
python3 nvidia/vllm/assets/verify_qwen36_tools.py --help
python3 nvidia/vllm/assets/verify_qwen36_tools.py --base-url http://127.0.0.1:8013

session 10/10: pass
PASS: 120 tool calls; mean latency 1.65s; max latency 4.48s
```
