### PR TITLE
Fix shebang placement in discover-sparks script

### DIFF
--- a/nvidia/connect-two-sparks/assets/discover-sparks
+++ b/nvidia/connect-two-sparks/assets/discover-sparks
@@ -1,3 +1,4 @@
+#!/bin/env bash
 #
 # SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-#!/bin/env bash
 
 # discover-sparks
 # Discover available systems using avahi-browse and generate MPI hosts file


### PR DESCRIPTION
This script doesn't work out of the box because the license file was prepended before the shebang and in an out-of-the-box setup with a new DGX Spark, this script fails because it executes with `sh` instead.

This patch relocates the shebang to properly execute the script with bash.