### PR TITLE
docs(nemoclaw): link dual DGX Spark setup

### DIFF
--- a/nvidia/nemoclaw/README.md
+++ b/nvidia/nemoclaw/README.md
@@ -39,6 +39,8 @@
   - [Step 8. Stop services](#step-8-stop-services)
   - [Step 9. Uninstall NemoClaw](#step-9-uninstall-nemoclaw)
 - [Troubleshooting](#troubleshooting)
+- [Multi-Node](#multi-node)
+  - [Run NemoClaw on Two DGX Sparks](#run-nemoclaw-on-two-dgx-sparks)
 
 ---
 
@@ -862,3 +864,21 @@ sudo sh -c 'sync; echo 3 > /proc/sys/vm/drop_caches'
 ```
 
 For the latest known issues, please review the [DGX Spark User Guide](https://docs.nvidia.com/dgx/dgx-spark/known-issues.html).
+
+---
+
+## Multi-Node
+
+### Run NemoClaw on Two DGX Sparks
+
+NemoClaw includes an Experimental managed vLLM profile for a qualified two-system DGX Spark cluster.
+DGX Spark Express can select this profile automatically when you keep option 1, **Managed vLLM with automatic serving-profile selection**.
+The profile serves DeepSeek V4 Flash 0731 through NemoClaw's managed `inference.local` route.
+
+> [!IMPORTANT]
+> This profile is Experimental because physical two-node end-to-end validation is pending.
+> Use it only for evaluation until the required validation is complete.
+
+Follow [Set Up vLLM on Two DGX Sparks](https://docs.nvidia.com/nemoclaw/latest/user-guide/openclaw/inference/local-inference/set-up-vllm-on-two-dgx-sparks) for qualification, network and storage requirements, trusted SSH setup, installation, verification, and cleanup.
+
+When no matching cluster qualifies during automatic selection, NemoClaw retains the single-DGX Spark managed vLLM path from the **Instructions** tab.


### PR DESCRIPTION
## Summary

The DGX Spark NemoClaw playbook now includes a Multi-Node section for NemoClaw's Experimental two-DGX Spark managed vLLM profile.
The section routes readers to the canonical qualification and installation guide, states the pending physical two-node validation, and explains the automatic single-DGX Spark fallback.

Fixes NVIDIA/NemoClaw#8782

## Changes

- Add the Multi-Node section and table-of-contents entry to the DGX Spark NemoClaw playbook.
- Link the canonical two-DGX Spark setup guide without duplicating its operational procedure.
- Keep the Experimental limitation and automatic single-DGX Spark fallback explicit.

## Validation

- `git diff --check` passed.
- Focused structural checks confirmed one Multi-Node heading, the nested two-DGX Spark heading, the canonical link, the Experimental limitation, and the absence of Station-specific commands.
- The canonical NVIDIA documentation link returned HTTP 200.
- An independent documentation writer review found no blocker or suggestion for commit `127d9995d1d73de793541dd5476b5a4a6cfc3c5b`.
- GitHub reports the commit signature as verified.

Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>
