### PR TITLE
docs(nemoclaw): forward stdin for tar uploads

### DIFF
--- a/nvidia/nemoclaw-applications/README.md
+++ b/nvidia/nemoclaw-applications/README.md
@@ -330,12 +330,12 @@ mkdir -p ~/nemoclaw-projects
 cp -r ~/projects/my-app ~/nemoclaw-projects/my-app
 ```
 
-Now copy that working copy **into** the sandbox at `/sandbox/project`. The reliable, dependency-free way is to stream a tar over `nemoclaw exec` — it needs nothing installed on the host and works on every sandbox:
+Now copy that working copy **into** the sandbox at `/sandbox/project`. The reliable, dependency-free way is to stream a tar over `nemoclaw exec --stdin`. The `--stdin` flag forwards the archive from the host into the sandbox:
 
 ```bash
 ## Push the project into the sandbox
 tar czf - -C ~/nemoclaw-projects/my-app . \
-  | nemoclaw $SANDBOX_NAME exec -- bash -lc 'mkdir -p /sandbox/project && tar xzf - -C /sandbox/project'
+  | nemoclaw $SANDBOX_NAME exec --stdin -- bash -lc 'mkdir -p /sandbox/project && tar xzf - -C /sandbox/project'
 ```
 
 Confirm the project landed and that the sandbox cannot reach the public internet (the local inference endpoint stays available regardless — that's how the agent talks to the model):
@@ -595,12 +595,12 @@ ignore_paths:
 
 ### Bind the red-team directory into the sandbox
 
-Copy the red-team directory **into** the sandbox at `/sandbox/redteam`. The reliable, dependency-free way is to stream a tar over `nemoclaw exec` — it needs nothing installed on the host and works on every sandbox:
+Copy the red-team directory **into** the sandbox at `/sandbox/redteam`. The reliable, dependency-free way is to stream a tar over `nemoclaw exec --stdin`. The `--stdin` flag forwards the archive from the host into the sandbox:
 
 ```bash
 ## Push queue/, corpus/, profile.yaml, reports/, memory/ into the sandbox
 tar czf - -C ~/nemoclaw-redteam . \
-  | nemoclaw $SANDBOX_NAME exec -- bash -lc 'mkdir -p /sandbox/redteam && tar xzf - -C /sandbox/redteam'
+  | nemoclaw $SANDBOX_NAME exec --stdin -- bash -lc 'mkdir -p /sandbox/redteam && tar xzf - -C /sandbox/redteam'
 ```
 
 (Optional, strongly recommended) Make `queue/`, `corpus/`, and `profile.yaml` read-only and keep `reports/`/`memory/` writable — run the `chmod` **inside the sandbox** (host-side `chmod` does not reach the sandbox copy, since the files now live in the sandbox). This denies the agent (which runs as the unprivileged `sandbox` user) write access to your source artifacts and ground-truth corpus:
@@ -1018,12 +1018,12 @@ preferences:
 
 ### Bind the calendar directory into the sandbox
 
-Copy the calendar directory **into** the sandbox at `/sandbox/calendar`. The reliable, dependency-free way is to stream a tar over `nemoclaw exec` — it needs nothing installed on the host and works on every sandbox:
+Copy the calendar directory **into** the sandbox at `/sandbox/calendar`. The reliable, dependency-free way is to stream a tar over `nemoclaw exec --stdin`. The `--stdin` flag forwards the archive from the host into the sandbox:
 
 ```bash
 ## Push calendar.ics, profile.yaml, and bookings/ into the sandbox
 tar czf - -C ~/nemoclaw-calendar . \
-  | nemoclaw $SANDBOX_NAME exec -- bash -lc 'mkdir -p /sandbox/calendar && tar xzf - -C /sandbox/calendar'
+  | nemoclaw $SANDBOX_NAME exec --stdin -- bash -lc 'mkdir -p /sandbox/calendar && tar xzf - -C /sandbox/calendar'
 ```
 
 (Optional, strongly recommended) Make `calendar.ics` and `profile.yaml` read-only and keep `bookings/` writable — run the `chmod` **inside the sandbox** (the files now live there, so a host-side `chmod` would not reach them). The agent runs as the unprivileged `sandbox` user, so this denies it any overwrite of your source-of-truth calendar:


### PR DESCRIPTION
## Summary

The NemoClaw applications playbook now opts into stdin forwarding for its three tar-over-exec uploads.
Previously, each workflow sent an archive to `nemoclaw exec` without `--stdin`, so the sandbox received an empty stream and the first workflow step failed.

## Related Issue

Fixes NVIDIA/NemoClaw#8781

## Changes

- Add `--stdin` to the Software Development Agent, Deck Reviewer, and Calendar Negotiator tar uploads.
- Explain that the flag forwards the host archive into the sandbox.
- Keep the sandbox-to-host tar downloads unchanged because they use remote stdout.

## Validation

- `git diff --check origin/main...HEAD` passed.
- Focused structural checks found 3 corrected uploads, 3 unchanged downloads, and 0 affected uploads without `--stdin`.
- `npx vitest run --project cli src/commands/sandbox/exec.test.ts src/lib/actions/sandbox/exec-stdio.test.ts --testTimeout=30000` passed 2 files and 16 tests in the NemoClaw checkout.
- An independent documentation writer review found no blockers or suggestions for commit `8b30a788f538e90d56f440236c0321fc1b6d987c`.
- GitHub reports the commit signature as verified.

Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>
