### PR TITLE
fix: use current Hugging Face filename for gpt-oss-20b GGUF

### DIFF
--- a/nvidia/multi-agent-chatbot/assets/model_download.sh
+++ b/nvidia/multi-agent-chatbot/assets/model_download.sh
@@ -44,6 +44,6 @@ download_if_needed "https://huggingface.co/ggml-org/gpt-oss-120b-GGUF/resolve/ma
 download_if_needed "https://huggingface.co/ggml-org/gpt-oss-120b-GGUF/resolve/main/gpt-oss-120b-mxfp4-00003-of-00003.gguf" "gpt-oss-120b-mxfp4-00003-of-00003.gguf"
 
 # Uncomment next line if you want to use gpt-oss-20b
-# download_if_needed "https://huggingface.co/ggml-org/gpt-oss-20b-GGUF/resolve/main/gpt-oss-20b-mxfp4.gguf" "gpt-oss-20b-mxfp4.gguf"
+# download_if_needed "https://huggingface.co/ggml-org/gpt-oss-20b-GGUF/resolve/main/gpt-oss-20b-MXFP4.gguf" "gpt-oss-20b-mxfp4.gguf"
 
 echo "All models downloaded."


### PR DESCRIPTION
Fixes #117

## Summary
- Hugging Face (`ggml-org/gpt-oss-20b-GGUF`) renamed the weights to `gpt-oss-20b-MXFP4.gguf`.
- The playbook download URL still used `gpt-oss-20b-mxfp4.gguf`, which returns a 15-byte `Entry not found` body instead of the ~12GB model.
- This updates only that URL. The local save name stays `gpt-oss-20b-mxfp4.gguf` so Compose still matches when the 20B line is uncommented.

## Test plan
- [x] Confirm https://huggingface.co/ggml-org/gpt-oss-20b-GGUF/resolve/main/gpt-oss-20b-MXFP4.gguf returns the GGUF (not `Entry not found`)
- [x] Uncomment the 20B download in `nvidia/multi-agent-chatbot/assets/model_download.sh` and run the script; file should be ~12GB
- [x] Confirm the 120B download lines are unchanged
