### PR TITLE
Add Wan2GP (WanGP) playbook — AI video generation on DGX Spark

### DIFF
--- a/nvidia/wan2gp/README.md
+++ b/nvidia/wan2gp/README.md
@@ -88,11 +88,15 @@ Two Spark-specific tips make a large difference:
   unified memory those are the same physical LPDDR5X, so that shuttle is wasted
   work — it dominates per-step time and can trigger out-of-memory failures on
   larger models. `--profile 3` keeps the whole model resident (easily within
-  128 GB) and is dramatically faster. Add `--teacache 2.0` for a further speed-up:
+  128 GB) and is dramatically faster:
 
   ```bash
-  bash assets/launch.sh --profile 3 --teacache 2.0
+  bash assets/launch.sh --profile 3
   ```
+
+  (WanGP also has a TeaCache step-cache for extra speed; enable it in the UI's
+  Advanced Mode if your version exposes it — the `--teacache` CLI flag is not
+  available in all WanGP versions.)
 
 - **If you hit an out-of-memory error mid-generation,** flush the Linux buffer
   cache, which can consume the unified memory pool on the Spark (a documented DGX

--- a/nvidia/wan2gp/README.md
+++ b/nvidia/wan2gp/README.md
@@ -1,0 +1,112 @@
+# Wan2GP (WanGP) — AI video generation on DGX Spark
+
+[Wan2GP](https://github.com/deepbeepmeep/Wan2GP) ("WanGP", by DeepBeepMeep) is a
+memory-efficient front end for a large family of open video models — Wan 2.1 / 2.2,
+LTX-2, Hunyuan Video, Qwen Image, Flux, and the **InfiniteTalk / MultiTalk**
+audio-driven talking-head models. This playbook installs it natively on a DGX
+Spark and reuses the same Blackwell PyTorch stack NVIDIA's ComfyUI playbook
+provides, so the fragile ARM + CUDA 13 pieces are already solved.
+
+## What you get
+
+- A dedicated `~/wan2gp-env` virtualenv (your ComfyUI install is untouched).
+- PyTorch 2.13.0+cu130 from the official cu130 wheel index (sm_121 / Blackwell).
+- Wan2GP cloned to `~/Wan2GP`, with every dependency landmine handled for aarch64.
+- A one-command launcher that serves the WanGP web UI on your LAN.
+
+## Prerequisites
+
+- DGX Spark (GB10) running DGX OS, Python 3.12.
+- ~40 GB free disk for the environment; model weights download on first use and
+  can be tens of GB more depending on which models you run.
+- Outbound internet access (PyPI, the PyTorch cu130 index, and Hugging Face).
+
+## Install
+
+```bash
+bash assets/setup.sh
+```
+
+The script installs system packages, creates the venv, installs the Blackwell
+PyTorch wheels, clones Wan2GP, and layers its dependencies on top. The final step
+prints a check confirming PyTorch sees the GB10 GPU (`cuda available: True`,
+`sm_121`).
+
+## Launch
+
+```bash
+bash assets/launch.sh
+```
+
+Then open the UI from any machine on your network:
+
+```
+http://<your-spark-hostname>.local:7860
+```
+
+Pick a model in the top dropdowns. For a talking-head clip, choose
+**Infinitetalk** (or **Multitalk**), then a **Single Speaker** or **Multi Speakers**
+variant, supply a reference image and one audio track per speaker, and Generate.
+Model weights download automatically on first use.
+
+## aarch64 / Blackwell specifics (why this playbook exists)
+
+Installing Wan2GP straight from its `requirements.txt` fails on the Spark for a
+handful of ARM-specific reasons. This playbook resolves each one:
+
+- **PyTorch**: installed from the cu130 index rather than the requirements' pins,
+  which resolve to x86 CUDA-12 wheels.
+- **Attention**: SageAttention / FlashAttention / xformers have no ARM wheels and
+  are skipped — Wan2GP falls back to PyTorch **sdpa** attention automatically.
+- **torchcodec / onnxruntime-gpu**: Wan2GP pins fast-moving nightly builds that
+  rotate off the index; the playbook installs current, ARM-compatible builds
+  instead (torchcodec from cu130; CPU onnxruntime, since onnxruntime-gpu has no
+  ARM wheel).
+- **decord**: no ARM wheel exists; it is skipped (only used for video-*input*
+  decoding — image + audio talking-head workflows do not need it).
+- **rembg**: installed as the CPU build (its `[gpu]` extra requires
+  onnxruntime-gpu).
+- **audio-separator**: installed explicitly (needed by InfiniteTalk / MultiTalk
+  vocal extraction; its default extra also pulls onnxruntime-gpu).
+- **transformers**: pinned to `4.54.0` (Wan2GP's target). transformers 5.x ships
+  a `higgs_audio_v2_tokenizer` that collides with Wan2GP's bundled OmniVoice TTS.
+- **python3.12-dev / build-essential**: installed so Triton can JIT-compile
+  kernels instead of rolling back to CPU.
+
+## Performance on the Spark
+
+The Spark's strength is capacity (128 GB unified memory), not raw memory
+bandwidth, and video diffusion is bandwidth-bound — so expect generation to be
+slower than a high-end discrete GPU. That is inherent to the LPDDR5X memory, not a
+misconfiguration. The payoff is running large models and long clips that would not
+fit on a smaller consumer card.
+
+Two Spark-specific tips make a large difference:
+
+- **Launch with `--profile 3`.** WanGP's default profile (4) *offloads* the model
+  and streams weights between "reserved RAM" and "VRAM" every step. On the Spark's
+  unified memory those are the same physical LPDDR5X, so that shuttle is wasted
+  work — it dominates per-step time and can trigger out-of-memory failures on
+  larger models. `--profile 3` keeps the whole model resident (easily within
+  128 GB) and is dramatically faster. Add `--teacache 2.0` for a further speed-up:
+
+  ```bash
+  bash assets/launch.sh --profile 3 --teacache 2.0
+  ```
+
+- **If you hit an out-of-memory error mid-generation,** flush the Linux buffer
+  cache, which can consume the unified memory pool on the Spark (a documented DGX
+  Spark behaviour):
+
+  ```bash
+  sudo sh -c 'sync; echo 3 > /proc/sys/vm/drop_caches'
+  ```
+
+Background-removal and audio-separation helpers run on CPU (onnxruntime-gpu has no
+ARM build), which is fine for those auxiliary steps.
+
+## Credits
+
+Wan2GP is created and maintained by DeepBeepMeep:
+https://github.com/deepbeepmeep/Wan2GP. This playbook only automates its
+installation on DGX Spark.

--- a/nvidia/wan2gp/assets/launch.sh
+++ b/nvidia/wan2gp/assets/launch.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Launch the Wan2GP (WanGP) web UI on a DGX Spark, exposed on the LAN.
+# Open it from another machine at  http://<spark-hostname>.local:7860
+set -euo pipefail
+
+ENV_DIR="${WAN2GP_ENV_DIR:-$HOME/wan2gp-env}"
+REPO_DIR="${WAN2GP_REPO_DIR:-$HOME/Wan2GP}"
+
+# shellcheck disable=SC1091
+source "$ENV_DIR/bin/activate"
+cd "$REPO_DIR"
+
+# --listen binds Gradio to 0.0.0.0 so the UI is reachable from the LAN.
+# Run `python wgp.py --help` to see all options (port, profiles, etc.).
+python wgp.py --listen "$@"

--- a/nvidia/wan2gp/assets/setup.sh
+++ b/nvidia/wan2gp/assets/setup.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# =============================================================================
+#  Wan2GP (WanGP) — DGX Spark setup
+# -----------------------------------------------------------------------------
+#  Installs deepbeepmeep's Wan2GP AI video generator natively on a DGX Spark
+#  (GB10 Grace-Blackwell, aarch64, CUDA 13), including the InfiniteTalk /
+#  MultiTalk audio-driven talking-head models.
+#
+#  Design notes for the Spark / aarch64 / Blackwell:
+#    * PyTorch is installed from the official cu130 wheel index (sm_121 build),
+#      the same source NVIDIA's ComfyUI playbook uses. This is the piece that
+#      normally breaks on ARM+Blackwell, so we reuse the known-good wheels.
+#    * A DEDICATED venv (~/wan2gp-env) is created so an existing ComfyUI
+#      install (~/comfyui-env) is never disturbed.
+#    * SageAttention / FlashAttention / xformers are skipped — they have no
+#      ARM wheels. Wan2GP falls back to PyTorch's built-in sdpa attention.
+#    * A few of Wan2GP's requirements pin fast-moving nightly builds
+#      (torchcodec, onnxruntime-gpu) that rotate off the index, or have no ARM
+#      wheel at all (decord); these are handled explicitly below.
+#    * transformers is pinned to 4.54.0 (Wan2GP's target); newer 5.x ships a
+#      model that collides with Wan2GP's bundled OmniVoice TTS.
+#
+#  Tested on: DGX Spark (GB10), DGX OS, Python 3.12, PyTorch 2.13.0+cu130.
+# =============================================================================
+set -euo pipefail
+
+CU130="https://download.pytorch.org/whl/cu130"
+ENV_DIR="${WAN2GP_ENV_DIR:-$HOME/wan2gp-env}"
+REPO_DIR="${WAN2GP_REPO_DIR:-$HOME/Wan2GP}"
+
+echo "=== [1/7] System packages ==="
+# python3.12-dev + build-essential give Triton the Python.h headers it needs to
+# JIT-compile CUDA kernels (otherwise it silently rolls back to CPU).
+sudo apt-get update -y
+sudo apt-get install -y git ffmpeg build-essential python3.12-dev
+
+echo "=== [2/7] Create dedicated venv at $ENV_DIR ==="
+[ -d "$ENV_DIR" ] || python3.12 -m venv "$ENV_DIR"
+# shellcheck disable=SC1091
+source "$ENV_DIR/bin/activate"
+python -m pip install --upgrade pip wheel setuptools
+
+echo "=== [3/7] Install Blackwell PyTorch from the cu130 index ==="
+# Validated versions for the Spark; bump together if you retest a newer set.
+pip install --index-url "$CU130" "torch==2.13.0" "torchvision==0.28.0" torchaudio
+
+echo "=== [4/7] Clone / update Wan2GP ==="
+if [ -d "$REPO_DIR/.git" ]; then
+  git -C "$REPO_DIR" pull --ff-only || true
+else
+  git clone https://github.com/deepbeepmeep/Wan2GP.git "$REPO_DIR"
+fi
+
+echo "=== [5/7] Install Wan2GP dependencies (torch pinned; ARM-incompatible libs skipped) ==="
+cat > /tmp/wan2gp-constraints.txt <<EOF
+torch==2.13.0+cu130
+torchvision==0.28.0+cu130
+transformers==4.54.0
+EOF
+# Strip torch* (incl. torchcodec), the pinned onnxruntime nightlies, decord
+# (no ARM wheel), rembg's [gpu] extra, and compile-only attention libraries.
+# These are installed with working substitutes in step [6].
+# Boundary is "any non-package-name character or end of line" so it also catches
+# environment markers (decord; ...) and extras (rembg[gpu]).
+grep -viE '^[[:space:]]*(torch|torchvision|torchaudio|torchcodec|onnxruntime-gpu|onnxruntime|decord|rembg|sageattention|flash[_-]?attn|flash-attention|xformers)([^A-Za-z0-9._-]|$)' \
+  "$REPO_DIR/requirements.txt" > /tmp/wan2gp-reqs.txt || true
+
+# Fast path: a fully-resolved install. If it fails, retry line-by-line so every
+# remaining problem package surfaces at once instead of one-per-run.
+if ! pip install -r /tmp/wan2gp-reqs.txt -c /tmp/wan2gp-constraints.txt; then
+  echo ">>> Batch install failed; retrying line-by-line to surface all problem packages..."
+  : > /tmp/wan2gp-failed.txt
+  while IFS= read -r line; do
+    [ -z "${line//[[:space:]]/}" ] && continue
+    case "$line" in \#*) continue;; esac
+    pip install "$line" -c /tmp/wan2gp-constraints.txt >/dev/null 2>&1 \
+      || echo "$line" >> /tmp/wan2gp-failed.txt
+  done < /tmp/wan2gp-reqs.txt
+  [ -s /tmp/wan2gp-failed.txt ] && { echo ">>> Could not install:"; cat /tmp/wan2gp-failed.txt; }
+fi
+
+echo "=== [6/7] Install ARM-friendly substitutes ==="
+# torchcodec: pinned version has no ARM/py3.12 wheel; take the cu130-matched one.
+pip install --index-url "$CU130" torchcodec || pip install torchcodec || \
+  echo "WARN: torchcodec not installed (only needed for video-INPUT decoding)."
+# onnxruntime: GPU build has no ARM wheel; CPU build serves the ONNX helpers.
+pip install onnxruntime-gpu || pip install onnxruntime || \
+  echo "WARN: onnxruntime not installed (background-removal / audio-separation helpers)."
+# rembg: install the CPU build (the [gpu] extra requires ARM-less onnxruntime-gpu).
+pip install "rembg==2.0.65" || pip install rembg || \
+  echo "WARN: rembg not installed (wgp.py imports it at startup)."
+# audio-separator: needed by InfiniteTalk/MultiTalk vocal extraction.
+pip install "audio-separator==0.36.1" || pip install --no-deps "audio-separator==0.36.1" || \
+  echo "WARN: audio-separator not installed (InfiniteTalk/MultiTalk preprocessing)."
+
+echo "=== [7/7] Sanity check: PyTorch sees the Blackwell GPU ==="
+python - <<'PY'
+import torch
+print("torch          :", torch.__version__)
+print("cuda available :", torch.cuda.is_available())
+if torch.cuda.is_available():
+    print("device         :", torch.cuda.get_device_name(0))
+    cap = torch.cuda.get_device_capability(0)
+    print("compute cap    :", f"sm_{cap[0]}{cap[1]}")
+PY
+
+echo
+echo "============================================================"
+echo " Wan2GP install complete."
+echo " Launch with:  bash \"$(dirname "$0")/launch.sh\""
+echo "============================================================"


### PR DESCRIPTION
## Summary

Adds a new `nvidia/wan2gp/` playbook that installs **Wan2GP (WanGP)** — a memory-efficient front end for open video models (Wan 2.1/2.2, LTX-2, Hunyuan Video, Qwen Image, Flux, and the **InfiniteTalk / MultiTalk** audio-driven talking-head models) — natively on a DGX Spark. It reuses the same cu130 PyTorch stack as the existing ComfyUI playbook, in a dedicated venv so an existing ComfyUI install is left untouched.

## Why

Installing Wan2GP straight from its `requirements.txt` fails on the Spark for several aarch64 / Blackwell-specific reasons:

- torch pins resolve to x86 CUDA-12 wheels
- SageAttention / FlashAttention / xformers and `decord` have no ARM wheels
- `torchcodec` and `onnxruntime-gpu` pin fast-moving nightly builds that rotate off the index
- `transformers` 5.x ships a `higgs_audio_v2_tokenizer` that collides with Wan2GP's bundled OmniVoice TTS

This playbook resolves each one so users get a working install + web UI from a single script, in a dedicated venv that leaves an existing ComfyUI install untouched.

## What's included

- `nvidia/wan2gp/README.md` — overview, prerequisites, install/launch steps, aarch64/Blackwell notes, and Spark performance tips (`--profile 3`, buffer-cache flush).
- `nvidia/wan2gp/assets/setup.sh` — one-command installer.
- `nvidia/wan2gp/assets/launch.sh` — launches the WanGP web UI on the LAN.

## Testing

Validated on a DGX Spark (GB10, DGX OS, Python 3.12):

- Clean-room Docker build running `setup.sh` from a bare Ubuntu container → PyTorch sees the GB10 (`sm_121`), all dependencies import, `transformers` pinned to 4.54.0.
- End-to-end text-to-video generation completed inside the container.

## Credits

Wan2GP is created and maintained by DeepBeepMeep (https://github.com/deepbeepmeep/Wan2GP). This playbook only automates its installation on DGX Spark.