### PR TITLE
nccl playbook: document NCCL_IB_HCA + MTU for full 200 Gbps on a single QSFP cable, warn about 16G test OOM

### DIFF
--- a/nvidia/nccl/README.md
+++ b/nvidia/nccl/README.md
@@ -172,7 +172,46 @@ mpirun -np 2 -H <management IP for Node 1>:1,<management IP for Node 2>:1 \
   $HOME/nccl-tests/build/all_gather_perf
 ```
 
+> [!IMPORTANT]
+> **Reaching full 200 Gbps bandwidth.** This section assumes a **single QSFP
+> cable** between the two Sparks (200 Gbps is the maximum a single cable can
+> carry). Each Spark exposes that one port as **two PCIe Gen5 x4 endpoints**
+> (~100 Gbps each), so NCCL must use *both* to saturate the link. The variables
+> above only select the *bootstrap* interface; NCCL chooses the data path
+> itself. To aggregate both halves, pin the RoCE devices explicitly and use
+> jumbo frames:
+>
+> ```bash
+> # On both nodes: use both RoCE halves of the QSFP port
+> # (exact device names from ibdev2netdev; the mixed capitalization
+> # below is real on DGX Spark, not a typo)
+> export NCCL_IB_HCA=rocep1s0f0,roceP2p1s0f0
+>
+> # On both nodes: jumbo frames on the CX-7 interfaces
+> sudo ip link set enp1s0f0np0 mtu 9000
+> sudo ip link set enP2p1s0f0np0 mtu 9000
+> ```
+>
+> Verify in the test output (with `NCCL_DEBUG=INFO`) that you see
+> `NET/IB : Using [0]rocep1s0f0:1/RoCE [1]roceP2p1s0f0:1/RoCE`.
+> Expected result with the large-buffer test below: **busbw ≈ 20-24 GB/s**
+> (~190 Gbps), i.e. ~95% of the single-cable line rate. If you see ~3 GB/s
+> regardless of buffer size, see Troubleshooting.
+
 You can also test your NCCL setup with a larger buffer size to use more of your 200Gbps bandwidth.
+
+> [!WARNING]
+> **Unified memory OOM risk.** The 16 GB buffer test allocates ~32 GB per node
+> (send + receive buffers) in unified memory. With a desktop session active
+> (browser, RDP), this can exhaust memory and **freeze the system completely**
+> (physical power cycle required). Prefer a progressive sweep, which saturates
+> the link just as well:
+>
+> ```bash
+> $HOME/nccl-tests/build/all_gather_perf -b 512M -e 4G -f 2
+> ```
+>
+> Only use `-b 16G -e 16G` from a console/SSH session with the desktop closed.
 
 ```bash
 ## Set network interface environment variables (use your management network interface)
@@ -519,3 +558,6 @@ Now you can try running a larger distributed workload such as TRT-LLM or vLLM in
 | mpirun hangs or times out | SSH connectivity issues | 1. Test basic SSH connectivity: `ssh <remote_ip>` should work without password prompts<br>2. Try a simple mpirun test: `mpirun -np 2 -H <IP for Node 1>:1,<IP for Node 2>:1 hostname`<br>3. Verify SSH keys are setup correctly for all nodes |
 | Network interface not found | Wrong interface name or down status | Check interface status with `ibdev2netdev` and verify IP configuration |
 | NCCL build fails | Missing dependencies such as OpenMPI or incorrect CUDA version | Verify CUDA installation and required libraries are present |
+| busbw stuck at ~3 GB/s regardless of buffer size | NCCL using only part of the link, or a non-release NCCL build | 1. Re-run with `NCCL_DEBUG=INFO` and check for `NET/IB : Using [0]... [1]...` (both RoCE devices)<br>2. Set `NCCL_IB_HCA=rocep1s0f0,roceP2p1s0f0` (exact names from `ibdev2netdev`; mixed capitalization is real)<br>3. Build NCCL from an exact release tag (`git clone -b v2.30.7-1 ...`); on identical hardware and settings, a development-branch build measured 3 GB/s vs 23.7 GB/s from the release tag<br>4. Set MTU 9000 on the CX-7 interfaces |
+| System completely freezes during the 16 GB buffer test | Unified-memory OOM (desktop session active) | Physical power cycle, close desktop/RDP sessions, and validate with `-b 512M -e 4G -f 2` instead |
+

--- a/nvidia/nccl/README.md
+++ b/nvidia/nccl/README.md
@@ -187,9 +187,13 @@ mpirun -np 2 -H <management IP for Node 1>:1,<management IP for Node 2>:1 \
 > # below is real on DGX Spark, not a typo)
 > export NCCL_IB_HCA=rocep1s0f0,roceP2p1s0f0
 >
-> # On both nodes: jumbo frames on the CX-7 interfaces
-> sudo ip link set enp1s0f0np0 mtu 9000
-> sudo ip link set enP2p1s0f0np0 mtu 9000
+> # On both nodes: jumbo frames on the CX-7 interfaces.
+> # Port MTU 4200 gives an active_mtu of 4096, the recommended
+> # value for RoCE v2 (see "MTU Considerations for RoCE-based
+> # Applications" on the NVIDIA Enterprise Support portal).
+> # 9000 works but wastes buffer memory with no measurable gain.
+> sudo ip link set enp1s0f0np0 mtu 4200
+> sudo ip link set enP2p1s0f0np0 mtu 4200
 > ```
 >
 > Verify in the test output (with `NCCL_DEBUG=INFO`) that you see
@@ -558,6 +562,6 @@ Now you can try running a larger distributed workload such as TRT-LLM or vLLM in
 | mpirun hangs or times out | SSH connectivity issues | 1. Test basic SSH connectivity: `ssh <remote_ip>` should work without password prompts<br>2. Try a simple mpirun test: `mpirun -np 2 -H <IP for Node 1>:1,<IP for Node 2>:1 hostname`<br>3. Verify SSH keys are setup correctly for all nodes |
 | Network interface not found | Wrong interface name or down status | Check interface status with `ibdev2netdev` and verify IP configuration |
 | NCCL build fails | Missing dependencies such as OpenMPI or incorrect CUDA version | Verify CUDA installation and required libraries are present |
-| busbw stuck at ~3 GB/s regardless of buffer size | NCCL using only part of the link, or a non-release NCCL build | 1. Re-run with `NCCL_DEBUG=INFO` and check for `NET/IB : Using [0]... [1]...` (both RoCE devices)<br>2. Set `NCCL_IB_HCA=rocep1s0f0,roceP2p1s0f0` (exact names from `ibdev2netdev`; mixed capitalization is real)<br>3. Build NCCL from an exact release tag (`git clone -b v2.30.7-1 ...`); on identical hardware and settings, a development-branch build measured 3 GB/s vs 23.7 GB/s from the release tag<br>4. Set MTU 9000 on the CX-7 interfaces |
+| busbw stuck at ~3 GB/s regardless of buffer size | NCCL using only part of the link, or a non-release NCCL build | 1. Re-run with `NCCL_DEBUG=INFO` and check for `NET/IB : Using [0]... [1]...` (both RoCE devices)<br>2. Set `NCCL_IB_HCA=rocep1s0f0,roceP2p1s0f0` (exact names from `ibdev2netdev`; mixed capitalization is real)<br>3. Build NCCL from an exact release tag (`git clone -b v2.30.7-1 ...`); on identical hardware and settings, a development-branch build measured 3 GB/s vs 23.7 GB/s from the release tag<br>4. Set port MTU 4200 on the CX-7 interfaces (active_mtu 4096; 9000 adds no measurable gain and wastes buffer memory) |
 | System completely freezes during the 16 GB buffer test | Unified-memory OOM (desktop session active) | Physical power cycle, close desktop/RDP sessions, and validate with `-b 512M -e 4G -f 2` instead |
 


### PR DESCRIPTION
Fixes #102

## Problem

Following the NCCL playbook on 2 DGX Sparks (**single QSFP 200G DAC**, direct
connection, the maximum bandwidth possible with one cable, DGX OS 7.5.0,
kernel 6.17.0-1029-nvidia), `all_gather_perf`
reaches only **~3 GB/s busbw** regardless of buffer size, and the suggested
16 GB validation test **froze one node completely** (unified-memory OOM with
a desktop session active; physical power cycle required).

## Root causes identified

1. The playbook never explains that with a **single QSFP cable**, the port is
   exposed as two PCIe Gen5 x4 endpoints (~100 Gbps each), that
   `NCCL_SOCKET_IFNAME=enP7s7` only selects the *bootstrap* path, and that the
   *data* path should be pinned with
   `NCCL_IB_HCA=rocep1s0f0,roceP2p1s0f0` to aggregate both halves and reach
   the single-cable maximum (~200 Gbps).
2. No MTU guidance (CX-7 interfaces default to 1500).
3. NCCL build sensitivity: with MTU 9000 and `NCCL_IB_HCA` already set, a
   development-branch build plateaued at 3.04 GB/s; rebuilding from the
   release tag (v2.28.9-1, the only change between the two runs)
   measured 23.74 GB/s.
4. The 16 GB test buffer allocates ~32 GB per node in unified memory, enough
   for an OOM with any desktop workload running.

## Measurements (same hardware throughout)

| Configuration | busbw |
|---|---|
| Playbook as written (dev-branch NCCL build, MTU 1500) | 3.02-3.05 GB/s |
| Same + MTU 9000 (dev-branch build) | 3.04 GB/s |
| Same config, only NCCL rebuilt from release tag (v2.28.9-1) | **23.74 GB/s (~190 Gbps, ≈ 95% of single-cable line rate)** |
| Raw RDMA per port half (`ib_write_bw`) | 109 Gbps |

## Changes

- Step 5 (2 Sparks): IMPORTANT note on bootstrap vs data path,
  `NCCL_IB_HCA` pinning, MTU 9000, expected busbw range.
- Step 5 (2 Sparks): IMPORTANT note on bootstrap vs data path, NCCL_IB_HCA pinning, jumbo frames (port MTU 4200, active_mtu 4096 per NVIDIA's RoCE MTU guidance), expected busbw range.
- Troubleshooting: two new rows (low busbw, system freeze).