### PR TITLE
Detect degraded ConnectX-7 initialization before cluster setup

### DIFF
--- a/nvidia/connect-two-sparks/README.md
+++ b/nvidia/connect-two-sparks/README.md
@@ -43,6 +43,7 @@ a functional distributed computing environment.
 All required files for this playbook can be found [here on GitHub](https://github.com/NVIDIA/dgx-spark-playbooks/blob/main/nvidia/connect-two-sparks/)
 
 - [**discover-sparks.sh**](https://github.com/NVIDIA/dgx-spark-playbooks/blob/main/nvidia/connect-two-sparks/assets/discover-sparks) script for automatic node discovery and SSH key distribution
+- [**check-connectx-bandwidth**](https://github.com/NVIDIA/dgx-spark-playbooks/blob/main/nvidia/connect-two-sparks/assets/check-connectx-bandwidth) runs a bounded per-rail RDMA health check and detects the degraded 8-25 Gb/s initialization state
 
 ## Time & risk
 
@@ -284,3 +285,4 @@ sudo ip addr del 192.168.101.11/24 dev enP2p1s0f1np1  # Adjust the interface nam
 | "Network unreachable" errors | Network interfaces not configured | Verify netplan config and `sudo netplan apply` |
 | SSH authentication failures | SSH keys not properly distributed | Re-run `./discover-sparks` and enter passwords |
 | Node 2 not visible in cluster | Network connectivity issue | Verify QSFP cable connection, check IP configuration |
+| Link reports 200 Gb/s, but `iperf3` and `ib_write_bw` are both limited to about 8-25 Gb/s | ConnectX-7 did not leave its degraded initialization state after boot or a cable change | Run the [bounded bandwidth health check](assets/performance_benchmarking_guide.md#detect-a-degraded-connectx-7-initialization), then follow its reboot and full AC-disconnect recovery procedure |

--- a/nvidia/connect-two-sparks/assets/check-connectx-bandwidth
+++ b/nvidia/connect-two-sparks/assets/check-connectx-bandwidth
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+
+# Validate one DGX Spark ConnectX-7 rail with a bounded RDMA write test.
+#
+# This helper intentionally does not reset PCIe devices or change network state.
+# A client result between 8 and 25 Gb/s, together with a 200 Gb/s Ethernet link
+# and a PCIe Gen5 x4 link, identifies the known degraded initialization state.
+
+set -uo pipefail
+
+readonly EXIT_DEGRADED=1
+readonly EXIT_STALE_INITIALIZATION=2
+readonly DEFAULT_PORT=12000
+readonly DEFAULT_DURATION=5
+readonly DEFAULT_HEALTHY_MIN_GBPS=80
+
+mode=""
+device=""
+peer=""
+input_file=""
+port="$DEFAULT_PORT"
+duration="$DEFAULT_DURATION"
+healthy_min_gbps="$DEFAULT_HEALTHY_MIN_GBPS"
+
+usage() {
+    cat <<'EOF'
+Usage:
+  check-connectx-bandwidth --server --device DEVICE [options]
+  check-connectx-bandwidth --client PEER_IP --device DEVICE [options]
+  check-connectx-bandwidth --analyze FILE [--device DEVICE] [options]
+
+Modes:
+  --server              Run the bounded ib_write_bw server.
+  --client PEER_IP      Run the bounded client and classify its result.
+  --analyze FILE        Classify previously captured ib_write_bw output.
+                        Use - for standard input.
+
+Options:
+  --device DEVICE       RDMA device reported Up by ibdev2netdev.
+  --port PORT           TCP control port (default: 12000).
+  --duration SECONDS    Test duration (default: 5).
+  --healthy-min GBPS    Per-rail pass threshold (default: 80).
+  -h, --help            Show this help.
+
+Exit status:
+  0  Throughput is at or above the healthy threshold.
+  1  Invalid setup, failed test, or other degraded result.
+  2  8-25 Gb/s result consistent with the stale initialization state.
+EOF
+}
+
+die() {
+    echo "ERROR: $*" >&2
+    exit "$EXIT_DEGRADED"
+}
+
+is_positive_number() {
+    awk -v value="$1" 'BEGIN { exit !(value ~ /^[0-9]+([.][0-9]+)?$/ && value > 0) }'
+}
+
+while (($#)); do
+    case "$1" in
+        --server)
+            [[ -z "$mode" ]] || die "choose exactly one mode"
+            mode="server"
+            shift
+            ;;
+        --client)
+            [[ -z "$mode" ]] || die "choose exactly one mode"
+            (($# >= 2)) || die "--client requires a peer IP address"
+            mode="client"
+            peer="$2"
+            shift 2
+            ;;
+        --analyze)
+            [[ -z "$mode" ]] || die "choose exactly one mode"
+            (($# >= 2)) || die "--analyze requires a file path or -"
+            mode="analyze"
+            input_file="$2"
+            shift 2
+            ;;
+        --device)
+            (($# >= 2)) || die "--device requires an RDMA device"
+            device="$2"
+            shift 2
+            ;;
+        --port)
+            (($# >= 2)) || die "--port requires a value"
+            port="$2"
+            shift 2
+            ;;
+        --duration)
+            (($# >= 2)) || die "--duration requires a value"
+            duration="$2"
+            shift 2
+            ;;
+        --healthy-min)
+            (($# >= 2)) || die "--healthy-min requires a value"
+            healthy_min_gbps="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            die "unknown argument: $1"
+            ;;
+    esac
+done
+
+[[ -n "$mode" ]] || {
+    usage >&2
+    exit "$EXIT_DEGRADED"
+}
+if ! [[ "$port" =~ ^[0-9]+$ ]] || ((port < 1 || port > 65535)); then
+    die "invalid port: $port"
+fi
+if ! [[ "$duration" =~ ^[0-9]+$ ]] || ((duration < 1)); then
+    die "invalid duration: $duration"
+fi
+is_positive_number "$healthy_min_gbps" || die "invalid healthy threshold: $healthy_min_gbps"
+
+netdev=""
+link_speed_mbps=""
+pcie_gen5_x4="unknown"
+
+inspect_device() {
+    [[ -n "$device" ]] || die "--device is required for $mode mode"
+    command -v ibdev2netdev >/dev/null 2>&1 || die "ibdev2netdev is not installed"
+    command -v ethtool >/dev/null 2>&1 || die "ethtool is not installed"
+
+    local mapping
+    mapping=$(ibdev2netdev | awk -v rdma_device="$device" '$1 == rdma_device { print; exit }')
+    [[ -n "$mapping" ]] || die "RDMA device $device was not found by ibdev2netdev"
+    netdev=$(awk '{ print $5 }' <<<"$mapping")
+    [[ "$mapping" == *"(Up)"* ]] || die "$device maps to $netdev, but it is not Up"
+
+    link_speed_mbps=$(ethtool "$netdev" 2>/dev/null | awk '
+        /^[[:space:]]*Speed:/ {
+            split($0, parts, /:[[:space:]]*/)
+            sub(/Mb\/s$/, "", parts[2])
+            print parts[2]
+            exit
+        }
+    ')
+    local firmware
+    firmware=$(ethtool -i "$netdev" 2>/dev/null | awk -F': ' '/^firmware-version:/ { print $2; exit }')
+
+    local bdf=""
+    local link_status=""
+    if [[ -e "/sys/class/infiniband/$device/device" ]]; then
+        bdf=$(basename "$(readlink -f "/sys/class/infiniband/$device/device")")
+    fi
+    if [[ -n "$bdf" ]]; then
+        local pcie_speed=""
+        local pcie_width=""
+        pcie_speed=$(cat "/sys/bus/pci/devices/$bdf/current_link_speed" 2>/dev/null || true)
+        pcie_width=$(cat "/sys/bus/pci/devices/$bdf/current_link_width" 2>/dev/null || true)
+        if [[ -n "$pcie_speed" && -n "$pcie_width" ]]; then
+            link_status="$pcie_speed, Width x$pcie_width"
+        elif command -v lspci >/dev/null 2>&1; then
+            link_status=$(lspci -s "$bdf" -vv 2>/dev/null | awk '/LnkSta:/ { print; exit }')
+        fi
+
+        if [[ "$link_status" == *"32.0 GT/s"* && "$link_status" == *"Width x4"* ]] ||
+           [[ "$link_status" == *"Speed 32GT/s"* && "$link_status" == *"Width x4"* ]]; then
+            pcie_gen5_x4="yes"
+        elif [[ -n "$link_status" ]]; then
+            pcie_gen5_x4="no"
+        fi
+    fi
+
+    echo "ConnectX-7 preflight"
+    echo "  RDMA device: $device"
+    echo "  network interface: $netdev"
+    echo "  negotiated speed: ${link_speed_mbps:-unknown} Mb/s"
+    echo "  firmware: ${firmware:-unknown}"
+    local link_status_display=${link_status#*LnkSta: }
+    echo "  PCIe link: ${link_status_display:-unknown}"
+
+    if command -v journalctl >/dev/null 2>&1 &&
+       journalctl -k -b --no-pager 2>/dev/null |
+           awk '/Detected insufficient power on the PCIe slot/ { found = 1 } END { exit !found }'; then
+        echo "  note: the mlx5 27 W warning is present; it also occurs on healthy systems"
+    fi
+}
+
+extract_bandwidth() {
+    awk '
+        $1 ~ /^[0-9]+$/ &&
+        $2 ~ /^[0-9]+$/ &&
+        $4 ~ /^[0-9]+([.][0-9]+)?$/ {
+            bandwidth = $4
+        }
+        END {
+            if (bandwidth != "") print bandwidth
+        }
+    ' "$1"
+}
+
+classify_bandwidth() {
+    local bandwidth_gbps="$1"
+    echo "Measured bandwidth: $bandwidth_gbps Gb/s"
+
+    if awk -v measured="$bandwidth_gbps" -v minimum="$healthy_min_gbps" \
+        'BEGIN { exit !(measured >= minimum) }'; then
+        echo "PASS: throughput meets the ${healthy_min_gbps} Gb/s per-rail health threshold"
+        return 0
+    fi
+
+    if awk -v measured="$bandwidth_gbps" \
+        'BEGIN { exit !(measured >= 8 && measured <= 25) }'; then
+        if [[ -n "$device" && ("$link_speed_mbps" != "200000" || "$pcie_gen5_x4" == "no") ]]; then
+            echo "DEGRADED: throughput is in the 8-25 Gb/s range, but link negotiation or PCIe width also needs attention" >&2
+            return "$EXIT_DEGRADED"
+        fi
+
+        cat >&2 <<'EOF'
+STALE INITIALIZATION STATE: throughput is in the characteristic 8-25 Gb/s range.
+Keep the final QSFP topology connected, reboot both endpoints, and retest. If the
+cap remains, shut down both endpoints, disconnect each Spark and its power brick
+from AC for at least 60 seconds, reconnect power without moving the QSFP cables,
+boot, and retest. This tool does not reset hardware automatically.
+EOF
+        return "$EXIT_STALE_INITIALIZATION"
+    fi
+
+    echo "DEGRADED: throughput is below the ${healthy_min_gbps} Gb/s per-rail health threshold" >&2
+    return "$EXIT_DEGRADED"
+}
+
+run_test() {
+    command -v ib_write_bw >/dev/null 2>&1 || die "ib_write_bw is not installed; install the perftest package"
+    inspect_device
+
+    local command=(
+        ib_write_bw
+        -d "$device"
+        -i 1
+        -p "$port"
+        -F
+        --report_gbits
+        -q 4
+        -D "$duration"
+    )
+    if [[ "$mode" == "client" ]]; then
+        command+=("$peer")
+    fi
+
+    local output
+    output=$(mktemp)
+    trap 'rm -f "$output"' EXIT
+
+    echo "Running: ${command[*]}"
+    "${command[@]}" 2>&1 | tee "$output"
+    local test_status=${PIPESTATUS[0]}
+    ((test_status == 0)) || die "ib_write_bw failed with status $test_status"
+
+    local bandwidth_gbps
+    bandwidth_gbps=$(extract_bandwidth "$output")
+    [[ -n "$bandwidth_gbps" ]] || die "could not parse average bandwidth from ib_write_bw output"
+    classify_bandwidth "$bandwidth_gbps"
+}
+
+case "$mode" in
+    server|client)
+        run_test
+        ;;
+    analyze)
+        if [[ -n "$device" ]]; then
+            inspect_device
+        fi
+        if [[ "$input_file" == "-" ]]; then
+            input_file=$(mktemp)
+            trap 'rm -f "$input_file"' EXIT
+            cat >"$input_file"
+        else
+            [[ -r "$input_file" ]] || die "cannot read $input_file"
+        fi
+        bandwidth_gbps=$(extract_bandwidth "$input_file")
+        [[ -n "$bandwidth_gbps" ]] || die "could not parse average bandwidth from $input_file"
+        classify_bandwidth "$bandwidth_gbps"
+        ;;
+esac

--- a/nvidia/connect-two-sparks/assets/performance_benchmarking_guide.md
+++ b/nvidia/connect-two-sparks/assets/performance_benchmarking_guide.md
@@ -32,6 +32,7 @@ Before running any benchmarks, ensure the following prerequisites are met for yo
 
 ### Dual Spark
 - [Measure bandwidth for Dual Spark setup](#measure-bw-between-dual-sparks)
+  - [Detect a degraded ConnectX-7 initialization](#detect-a-degraded-connectx-7-initialization)
 - [Measure RDMA latency between Dual Sparks](#measure-rdma-latency-between-dual-sparks)
 
 ---
@@ -916,6 +917,45 @@ nvidia@spark-bd26:~$ ib_write_bw -d roceP2p1s0f0 -i 1 -p 12001 -F --report_gbits
 ```
 
 **Total throughput = 92.57 + 97.28 = 189.85 Gbps**
+
+### Detect a degraded ConnectX-7 initialization
+
+A ConnectX-7 endpoint can occasionally remain in a degraded initialization state after boot or a QSFP cable change. In this state, `ethtool` still reports a 200 Gb/s link, PCIe still reports 32 GT/s x4, and link error counters can remain clean, but both TCP and raw RDMA throughput are limited to approximately 8-25 Gb/s per rail. Changing MTU, TCP buffers, or queue counts does not correct this state.
+
+Use the bounded health-check helper to test a single rail. It validates the local link, runs `ib_write_bw` for five seconds, and returns status 2 when the result matches the degraded initialization signature.
+
+On the host Spark:
+
+```bash
+cd dgx-spark-playbooks/nvidia/connect-two-sparks/assets
+./check-connectx-bandwidth --server --device rocep1s0f0 --port 12000
+```
+
+Then run the client against the IP on the same rail:
+
+```bash
+cd dgx-spark-playbooks/nvidia/connect-two-sparks/assets
+./check-connectx-bandwidth \
+  --client 192.168.200.12 \
+  --device rocep1s0f0 \
+  --port 12000
+```
+
+Replace the device, IP address, and port with the values for the rail under test. Repeat in the reverse direction because an endpoint can be degraded in only one direction. A healthy rail should exceed the helper's conservative 80 Gb/s threshold; NVIDIA's example above measures 92.57 and 97.28 Gb/s on the two rails.
+
+> [!NOTE]
+> The mlx5 messages `PCIe slot power capability was not advertised` and `Detected insufficient power on the PCIe slot (27W)` can also occur on systems delivering healthy bandwidth. Do not use those messages alone to diagnose the degraded state; confirm it with a bandwidth measurement.
+
+If the helper reports `STALE INITIALIZATION STATE`:
+
+1. Stop distributed workloads on the affected endpoints.
+2. Connect the final intended QSFP topology and do not move or reconnect the cables during recovery.
+3. Update DGX OS and firmware by following the [DGX Spark update guide](https://docs.nvidia.com/dgx/dgx-spark/os-and-component-update.html).
+4. Reboot both endpoints with the final topology connected, then run the health check in both directions again.
+5. If the cap remains, run `sudo shutdown -h now` on both endpoints and wait for shutdown to finish. Disconnect the USB-C power cable from each Spark and disconnect each power adapter from its AC outlet. Wait at least 60 seconds, reconnect power without moving the QSFP cables, boot, and retest.
+6. If throughput remains degraded, collect an `nvidia-bug-report.sh` bundle and contact NVIDIA support. Repeated PCIe fatal AER errors should also be escalated rather than treated as this initialization state.
+
+The helper deliberately does not reset PCIe devices or unload drivers. Those operations interrupt the network and are not a verified substitute for the recovery sequence.
 
 ## Measure RDMA Latency Between Dual Sparks
 

--- a/nvidia/multi-sparks-through-switch/README.md
+++ b/nvidia/multi-sparks-through-switch/README.md
@@ -53,6 +53,7 @@ All required files for this playbook can be found [here on GitHub](https://githu
 
 - [**discover-sparks.sh**](https://github.com/NVIDIA/dgx-spark-playbooks/blob/main/nvidia/connect-two-sparks/assets/discover-sparks) script for automatic node discovery and SSH key distribution
 - [**Cluster setup script**](https://github.com/NVIDIA/dgx-spark-playbooks/blob/main/nvidia/multi-sparks-through-switch/assets/spark_cluster_setup) for automatic network configuration, validation and running NCCL sanity test
+- [**check-connectx-bandwidth**](https://github.com/NVIDIA/dgx-spark-playbooks/blob/main/nvidia/connect-two-sparks/assets/check-connectx-bandwidth) runs a bounded per-rail RDMA health check and detects the degraded 8-25 Gb/s initialization state
 
 ## Time & risk
 
@@ -433,3 +434,4 @@ sudo netplan apply
 | Nodes not visible in cluster | Network connectivity issue | Verify QSFP cable connection, check IP configuration |
 | "APT update" errors (eg. E: The list of sources could not be read.) | APT sources errors, conflicting sources or signing keys | Check APT and Ubuntu documentation to fix the APT sources or keys conflicts |
 | NCCL test failures (eg. libnccl.so.2: cannot open shared object file) | NCCL configuration not done on all nodes | Make sure to follow the NCCL playbook to configure **all** nodes before running the NCCL test|
+| Links report 200 Gb/s, but `iperf3` and `ib_write_bw` are both limited to about 8-25 Gb/s | One or more ConnectX-7 endpoints did not leave their degraded initialization state after boot or a cable change | Test each Spark against a known-good peer with the [bounded bandwidth health check](../connect-two-sparks/assets/performance_benchmarking_guide.md#detect-a-degraded-connectx-7-initialization), then follow its reboot and full AC-disconnect recovery procedure |


### PR DESCRIPTION
## Problem

A DGX Spark ConnectX-7 endpoint can negotiate Ethernet at 200 Gb/s and PCIe at Gen5 x4 while TCP and raw RDMA remain capped near 13 Gb/s. This makes the existing link-speed check pass even though distributed workloads receive a fraction of the expected fabric bandwidth.

This was reproduced on four fully updated Sparks running DGX OS 7.5.0 and ConnectX firmware 28.45.4028: TCP measured 12.86 Gb/s and an eight-QP `ib_write_bw` test measured 13.23 Gb/s, with clean link counters. The guide examples measure 92.57 and 97.28 Gb/s per logical interface. Similar boot/hot-plug behavior and recovery results are reported in the [NVIDIA developer forum](https://forums.developer.nvidia.com/t/connectx-7-inter-spark-link-capped-at-13-gbps-expected-200-gbps-pcie-power-throttling-27w/363461).

The mlx5 27 W warning is not used as a failure signal because it also appears on systems delivering healthy bandwidth.

## Change

- Add `check-connectx-bandwidth`, a bounded per-rail RDMA preflight that reports the RDMA/netdev mapping, negotiated Ethernet speed, firmware, and PCIe link state.
- Return a distinct status 2 for the characteristic 8-25 Gb/s result when the physical and PCIe links are otherwise healthy.
- Document bidirectional validation for direct and switched topologies.
- Document recovery with the final QSFP topology connected: reboot and retest, then perform a complete shutdown and at least 60-second AC disconnect if the cap persists.
- Explicitly avoid automated PCIe resets or driver unloads because they are disruptive and are not a verified substitute for cold recovery.

## Validation

- `bash -n nvidia/connect-two-sparks/assets/check-connectx-bandwidth`
- `shellcheck nvidia/connect-two-sparks/assets/check-connectx-bandwidth`
- Parser fixtures: 92.57 Gb/s -> 0, 13.23 Gb/s -> 2, 50 Gb/s -> 1, malformed output -> 1
- Live read-only classification of the captured 13.23 Gb/s result confirmed 200000 Mb/s, firmware 28.45.4028, PCIe 32.0 GT/s x4, and exit status 2
- `git diff --check`

## Limitation

The helper detects and guides recovery from the state; it does not change proprietary ConnectX hot-plug firmware or reset live hardware.