### PR TITLE
fix txt2kg cold start: build local images, Node 20, Next security patch

### DIFF
--- a/nvidia/txt2kg/README.md
+++ b/nvidia/txt2kg/README.md
@@ -89,7 +89,9 @@ The script will automatically:
 
 ## Step 3. Pull an Ollama model (optional)
 
-Download a language model for knowledge extraction. The default model loaded is Llama 3.1 8B:
+On first start, the Ollama container entrypoint automatically downloads `llama3.1:8b` if it is not already present. Wait for that pull to finish before processing documents (`docker logs ollama-compose -f`).
+
+To use a different model:
 
 ```bash
 docker exec ollama-compose ollama pull <model-name>
@@ -158,9 +160,12 @@ docker exec ollama-compose ollama rm llama3.1:8b
 
 | Symptom | Cause | Fix |
 |---------|--------|-----|
+| `pull access denied` for `ollama-custom` / image does not exist | Local image was never built, or Compose tried to pull it from a registry | Run `./start.sh` (builds images) or `docker compose -f deploy/compose/docker-compose.yml up -d --build` from `assets/` |
+| Port `11434` already in use / Ollama container fails to start | Another process (often host `ollama serve`) or container is bound to 11434 | Free the port (`pkill -f 'ollama serve'` or stop the other container), then run `./start.sh` again |
+| Vector DB / Qdrant "not connected" | Vector search profile was not started | Expected without vector search. Start with `./start.sh --vector-search` if you need Qdrant |
 | Ollama performance issues | Suboptimal settings for DGX Spark | Set environment variables:<br>`OLLAMA_FLASH_ATTENTION=1` (enables flash attention for better performance)<br>`OLLAMA_KEEP_ALIVE=30m` (keeps model loaded for 30 minutes)<br>`OLLAMA_MAX_LOADED_MODELS=1` (avoids VRAM contention)<br>`OLLAMA_KV_CACHE_TYPE=q8_0` (reduces KV cache VRAM with minimal performance impact) |
 | VRAM exhausted or memory pressure (e.g. when switching between Ollama models) | Linux buffer cache consuming GPU memory | Flush buffer cache: `sudo sync; sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches'` |
-| Slow triple extraction | Large model or large context window | Reduce document chunk size or use faster models |
+| Slow triple extraction (even on small documents) | Default UI chunk size is 512 characters, so short files become many sequential LLM calls; first call also cold-loads the model | On **Process Documents**, raise chunk size (for example 4000–8000), or use a faster model. Wait for the initial model load to finish |
 | ArangoDB connection refused | Service not fully started | Wait 30s after start.sh, verify with `docker ps` |
 
 > [!NOTE]

--- a/nvidia/txt2kg/assets/README.md
+++ b/nvidia/txt2kg/assets/README.md
@@ -152,9 +152,14 @@ That's it! No configuration needed. The script will:
 - Launch Ollama with GPU acceleration
 - Start the Next.js frontend
 
-3. **Pull an Ollama model (first time only):**
+3. **Wait for the default Ollama model (first time only):**
+The Ollama entrypoint pulls `llama3.1:8b` automatically if needed. Check progress with:
 ```bash
-docker exec ollama-compose ollama pull llama3.1:8b
+docker logs ollama-compose -f
+```
+To use a different model:
+```bash
+docker exec ollama-compose ollama pull <model-name>
 ```
 
 4. **Access the application:**

--- a/nvidia/txt2kg/assets/deploy/README.md
+++ b/nvidia/txt2kg/assets/deploy/README.md
@@ -43,14 +43,14 @@ This directory contains all deployment-related configuration for the txt2kg proj
 
 ```bash
 # Default: ArangoDB + Ollama
-docker compose -f deploy/compose/docker-compose.yml up -d
+docker compose -f deploy/compose/docker-compose.yml up -d --build
 
 # Neo4j + vLLM
-docker compose -f deploy/compose/docker-compose.vllm.yml up -d
+docker compose -f deploy/compose/docker-compose.vllm.yml up -d --build
 
 # With vector search services (add --profile vector-search)
-docker compose -f deploy/compose/docker-compose.yml --profile vector-search up -d
-docker compose -f deploy/compose/docker-compose.vllm.yml --profile vector-search up -d
+docker compose -f deploy/compose/docker-compose.yml --profile vector-search up -d --build
+docker compose -f deploy/compose/docker-compose.vllm.yml --profile vector-search up -d --build
 ```
 
 ## Services Included

--- a/nvidia/txt2kg/assets/deploy/app/Dockerfile
+++ b/nvidia/txt2kg/assets/deploy/app/Dockerfile
@@ -1,10 +1,10 @@
 # Optimized multi-stage Dockerfile for faster builds
 # Stage 1: Dependencies
-FROM node:18-slim AS deps
+FROM node:20-slim AS deps
 WORKDIR /app
 
 # Install pnpm
-RUN npm install -g pnpm --force --yes
+RUN corepack enable && corepack prepare pnpm@10 --activate
 
 # Copy dependency files
 COPY ./frontend/package.json ./frontend/pnpm-lock.yaml* ./
@@ -19,11 +19,11 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
     fi
 
 # Stage 2: Builder
-FROM node:18-slim AS builder
+FROM node:20-slim AS builder
 WORKDIR /app
 
 # Install pnpm
-RUN npm install -g pnpm --force --yes
+RUN corepack enable && corepack prepare pnpm@10 --activate
 
 # Copy node_modules from deps stage
 COPY --from=deps /app/node_modules ./node_modules
@@ -33,23 +33,23 @@ COPY --from=deps /app/package.json ./package.json
 COPY ./frontend/ ./
 
 # Set build environment variables
-ENV NEXT_TELEMETRY_DISABLED 1
-ENV NODE_ENV production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV NODE_ENV=production
 
 # Build with cache mount for Next.js cache
 RUN --mount=type=cache,target=/app/.next/cache \
     pnpm build
 
 # Stage 3: Production runtime
-FROM node:18-slim AS runner
+FROM node:20-slim AS runner
 WORKDIR /app
 
-ENV NODE_ENV production
-ENV NEXT_TELEMETRY_DISABLED 1
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
 
 # Create non-root user for security
-RUN addgroup --system --gid 1001 nodejs && \
-    adduser --system --uid 1001 nextjs
+RUN groupadd --gid 1001 nodejs && \
+    useradd --uid 1001 --gid nodejs --no-create-home nextjs
 
 # Copy necessary files from builder
 COPY --from=builder /app/public ./public
@@ -63,7 +63,7 @@ USER nextjs
 
 EXPOSE 3000
 
-ENV PORT 3000
-ENV HOSTNAME "0.0.0.0"
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
 
 CMD ["node", "server.js"]

--- a/nvidia/txt2kg/assets/deploy/compose/docker-compose.complete.yml
+++ b/nvidia/txt2kg/assets/deploy/compose/docker-compose.complete.yml
@@ -95,6 +95,7 @@ services:
       context: ../services/ollama
       dockerfile: Dockerfile
     image: ollama-custom:latest
+    pull_policy: build
     container_name: ollama-compose
     ports:
       - '11434:11434'

--- a/nvidia/txt2kg/assets/deploy/compose/docker-compose.yml
+++ b/nvidia/txt2kg/assets/deploy/compose/docker-compose.yml
@@ -93,6 +93,7 @@ services:
       context: ../services/ollama
       dockerfile: Dockerfile
     image: ollama-custom:latest
+    pull_policy: build
     container_name: ollama-compose
     ports:
       - '11434:11434'

--- a/nvidia/txt2kg/assets/frontend/package.json
+++ b/nvidia/txt2kg/assets/frontend/package.json
@@ -49,7 +49,7 @@
     "langchain": "^0.3.19",
     "lucide-react": "^0.454.0",
     "neo4j-driver": "^5.28.1",
-    "next": "15.2.4",
+    "next": "15.2.9",
     "next-themes": "^0.4.4",
     "openai": "^4.91.0",
     "react": "^19",
@@ -60,6 +60,9 @@
     "tailwindcss-animate": "^1.0.7",
     "three": "^0.176.0",
     "zod": "^3.24.1"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["protobufjs"]
   },
   "devDependencies": {
     "@types/node": "^22",

--- a/nvidia/txt2kg/assets/start.sh
+++ b/nvidia/txt2kg/assets/start.sh
@@ -151,9 +151,9 @@ fi
 # Execute the command
 echo ""
 echo "Starting services..."
-echo "Running: $CMD $PROFILES up -d"
+echo "Running: $CMD $PROFILES up -d --build"
 cd $(dirname "$0")
-eval "$CMD $PROFILES up -d"
+eval "$CMD $PROFILES up -d --build"
 
 echo ""
 echo "=========================================="
@@ -189,8 +189,8 @@ if [ "$USE_VLLM" = true ]; then
   echo ""
   echo "  2. Open http://localhost:3001 in your browser"
 else
-  echo "  1. Pull an Ollama model (if not already done):"
-  echo "     docker exec ollama-compose ollama pull llama3.1:8b"
+  echo "  1. Wait for Ollama to finish pulling llama3.1:8b on first start"
+  echo "     (check logs with: docker logs ollama-compose -f)"
   echo ""
   echo "  2. Open http://localhost:3001 in your browser"
 fi


### PR DESCRIPTION
Fixes #118

## Summary
- Build local images on `./start.sh` (`up -d --build`) and set `pull_policy: build` for `ollama-custom` so Compose does not fail trying to pull a non-registry image
- Bump the app image to Node 20 and Next.js to 15.2.9 so production builds succeed and pick up the CVE patch
- Document common first-run footguns (port 11434 conflicts, optional Qdrant, slow small-doc extraction via chunk size, automatic model pull)

## Test plan
- [x] From `nvidia/txt2kg/assets`, run `./start.sh` on a machine without a prebuilt `ollama-custom` image and confirm images build / stack starts
- [x] Confirm UI responds at http://localhost:3001
- [x] Confirm Ollama container becomes healthy and (on first start) pulls `llama3.1:8b`
- [x] Optional: `./start.sh --vector-search` clears the Qdrant "not connected" status
- [x] If host Ollama already binds 11434, confirm README troubleshooting guidance matches the failure
