### PR TITLE
Add Agentic RAG with Provenance-Enforced Refusal playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Each playbook includes prerequisites, step-by-step instructions, troubleshooting
 
 ### NVIDIA
 
+- [Agentic RAG with Provenance-Enforced Refusal](nvidia/agentic-rag-provenance-refusal/)
 - [CLI Coding Agent](nvidia/cli-coding-agent/)
 - [Comfy UI](nvidia/comfy-ui/)
 - [Connect Three DGX Spark in a Ring Topology](nvidia/connect-three-sparks/)

--- a/nvidia/agentic-rag-provenance-refusal/README.md
+++ b/nvidia/agentic-rag-provenance-refusal/README.md
@@ -1,0 +1,262 @@
+# Agentic RAG with Provenance-Enforced Refusal on DGX Spark
+
+> Build a fully on-prem retrieval-augmented agent that answers **with a cited source or
+> refuses** — never invents — using Nemotron, NeMo Retriever embeddings, a reranker, and
+> Milvus, all served locally on your DGX Spark. No cloud APIs, no data leaving the machine.
+
+## Table of Contents
+
+- [Overview](#overview)
+  - [Notice & Disclaimers](#notice--disclaimers)
+- [What you'll accomplish](#what-youll-accomplish)
+- [Prerequisites](#prerequisites)
+- [Time & risk](#time--risk)
+- [Instructions](#instructions)
+- [Troubleshooting](#troubleshooting)
+- [Next steps](#next-steps)
+
+---
+
+## Overview
+
+### Basic idea
+
+A retrieval-augmented generation (RAG) agent is only as trustworthy as its weakest failure
+mode: **answering confidently when it shouldn't.** A model asked something outside its indexed
+knowledge will, by default, produce a fluent answer anyway — and often attach unrelated sources
+to it. In a private enterprise setting, that is not a cosmetic bug: it is the difference between
+a decision-support tool and a liability.
+
+This playbook builds the opposite behaviour on your DGX Spark, entirely on-prem:
+
+1. **Nemotron** (served via NIM) for reasoning.
+2. **NeMo Retriever embeddings** (asymmetric — `passage` when indexing, `query` when searching)
+   and a **reranker NIM** for relevance scoring.
+3. **Milvus** for the vector store, one collection per tenant.
+4. A **provenance-or-refusal** pattern: the agent decides *in code*, from the reranker's
+   relevance score, whether it has a good enough source **before** calling the generator. If it
+   doesn't, it refuses — and a refusal carries no sources.
+
+The 128 GB of unified memory on DGX Spark is what makes this comfortable: the reasoning model,
+the embedding model, the reranker, and the vector store all coexist on one device.
+
+This is the reference pattern behind **X9**, the internal "master" of the
+[Tribu SDK](https://sdk.tribucorp.es) — a proprietary agentic SDK built on the NVIDIA AI
+Factory stack. This playbook teaches the pattern with public NVIDIA components; the Tribu SDK
+is the production-hardened implementation of it (tenant isolation, signed audit, jurisdiction
+checks, red-teaming). You can build the pattern yourself from this playbook — the SDK is for
+teams who want it industrialised and supported.
+
+### Notice & Disclaimers
+
+#### Quick Start Safety Check
+
+Use a clean environment. Run this playbook on a device or VM with no personal data,
+confidential information, or production credentials until you have reviewed the security model
+for your own threat model. By installing this playbook you take responsibility for all
+third-party components, including their licenses and terms.
+
+#### Key risks with RAG agents
+
+1. **Overconfident answers** — the failure mode this playbook exists to reduce, but no
+   mitigation is perfect; measure it for your own corpus (see Step 8).
+2. **Prompt injection** — text inside a user's question can carry instructions the model may
+   obey. This playbook's refusal gate reduces *irrelevant* answers, but it is **not** an
+   injection defence on its own. Treat user input as untrusted.
+3. **Data leakage** — anything indexed is reachable by whoever can query. Apply access control
+   to the collection and to the endpoint.
+
+This playbook reduces risk through a structural refusal gate; it does not eliminate it. Verify
+behaviour against your own data before relying on it.
+
+---
+
+## What you'll accomplish
+
+You will serve three NIMs (reasoning, embedding, reranking) and Milvus on your DGX Spark, index
+a small document corpus, and run a query loop that (a) retrieves with hybrid search, (b) scores
+relevance with the reranker, (c) refuses below a calibrated threshold, and (d) otherwise answers
+citing the exact source. You will then **measure** the refusal behaviour with in-corpus and
+out-of-corpus questions — because a refusal gate you haven't measured is a guess.
+
+## Prerequisites
+
+**Hardware:**
+- NVIDIA DGX Spark with 128 GB unified memory.
+- Enough unified memory for three NIMs plus Milvus (the models below fit comfortably).
+
+**Software:**
+- NVIDIA DGX OS (Ubuntu 24.04 base).
+- Docker Engine running (`docker info`) with the NVIDIA Container Toolkit configured.
+- Python 3.12+ and the `uv` package manager (`curl -LsSf https://astral.sh/uv/install.sh | sh`).
+- An NGC API key to pull the NIM containers (`docker login nvcr.io`).
+- Network access to pull containers and model weights (the agent loop itself runs offline).
+
+## Time & risk
+
+- **Estimated time:** 40–60 minutes (plus NIM image and weight download time).
+- **Risk level:** Low. Everything runs locally; the query loop makes no outbound calls once the
+  NIMs are up. The refusal gate is additive — worst case, a misconfigured threshold refuses too
+  much or too little, which Step 8 is designed to catch.
+- **Rollback:** `docker compose down` for the NIMs and Milvus; delete the Python venv.
+
+---
+
+## Instructions
+
+## Step 1. Confirm your environment
+
+```bash
+head -n 2 /etc/os-release        # expect Ubuntu 24.04 (DGX OS)
+nvidia-smi                       # expect a detected GB10 GPU
+docker info --format '{{.ServerVersion}}'
+python3 --version                # expect 3.12+
+```
+
+## Step 2. Authenticate to NGC and pull the NIMs
+
+```bash
+docker login nvcr.io             # username: $oauthtoken, password: your NGC API key
+```
+
+> [!NOTE]
+> If `docker login nvcr.io` fails with a credential-helper error (`wb-svc` or similar), remove
+> `credsStore`/`credHelpers` from `~/.docker/config.json` and retry. NVIDIA AI Workbench
+> installs a helper that interferes with a plain login.
+
+Pull the three NIMs. Use the DGX Spark (GB10 / ARM64) variants:
+
+```bash
+docker pull nvcr.io/nim/nvidia/nvidia-nemotron-nano-9b-v2-dgx-spark:latest      # reasoning
+docker pull nvcr.io/nim/nvidia/llama-nemotron-embed-1b-v2:latest                # embeddings
+docker pull nvcr.io/nim/nvidia/llama-nemotron-rerank-vl-1b-v2:latest            # reranking
+```
+
+## Step 3. Serve the NIMs
+
+Serve reasoning on `:8001`, embeddings on `:8002`, reranking on `:8003`. Keep telemetry off —
+this is an on-prem deployment.
+
+```bash
+# reasoning
+docker run -d --name nim-llm --runtime=nvidia --gpus all \
+  -e NIM_TELEMETRY_MODE=0 -p 8001:8000 \
+  nvcr.io/nim/nvidia/nvidia-nemotron-nano-9b-v2-dgx-spark:latest
+
+# embeddings (asymmetric: needs input_type per call — see Step 6)
+docker run -d --name nim-embed --runtime=nvidia --gpus all \
+  -e NIM_TELEMETRY_MODE=0 -p 8002:8000 \
+  nvcr.io/nim/nvidia/llama-nemotron-embed-1b-v2:latest
+
+# reranking
+docker run -d --name nim-rerank --runtime=nvidia --gpus all \
+  -e NIM_TELEMETRY_MODE=0 -p 8003:8000 \
+  nvcr.io/nim/nvidia/llama-nemotron-rerank-vl-1b-v2:latest
+```
+
+Wait for each to report ready:
+
+```bash
+for p in 8001 8002 8003; do
+  curl -s -o /dev/null -w "port $p: %{http_code}\n" -m 5 localhost:$p/v1/health/ready
+done            # expect 200 on all three (may take a few minutes on first start)
+```
+
+## Step 4. Start Milvus
+
+```bash
+curl -sfL https://raw.githubusercontent.com/milvus-io/milvus/master/scripts/standalone_embed.sh -o milvus.sh
+bash milvus.sh start        # serves on localhost:19530
+```
+
+## Step 5. Set up the Python environment
+
+```bash
+cd ~ && uv venv rag-env && source rag-env/bin/activate
+uv pip install pymilvus httpx
+```
+
+## Step 6. Know the one gotcha: the embedding NIM is asymmetric
+
+`llama-nemotron-embed-1b-v2` returns **HTTP 400 without an `input_type` field**. Use
+`"passage"` when indexing documents and `"query"` when embedding a search. This is the single
+most common integration error with this model.
+
+```bash
+# indexing a document — input_type: passage
+curl -s localhost:8002/v1/embeddings -H 'Content-Type: application/json' -d '{
+  "model": "nvidia/llama-nemotron-embed-1b-v2",
+  "input": ["Tribucorp builds on the NVIDIA AI Factory stack."],
+  "input_type": "passage"
+}' | head -c 200
+```
+
+Note the model dimension the endpoint reports at startup — the 2026 ecosystem default is
+**2048**, not 1024. Your Milvus collection dimension must match, or retrieval fails closed.
+
+## Step 7. Index a corpus and run the provenance-or-refusal loop
+
+The reference script (`assets/agentic_rag.py`) does four things per query:
+
+1. Embed the question (`input_type: query`) and hybrid-search Milvus.
+2. Ask the reranker to score the candidates; keep the **top logit**.
+3. **If the top logit is below the refusal threshold, refuse — with an empty source list.**
+   This happens *before* any call to the reasoning model.
+4. Otherwise, build the context and ask Nemotron to answer **citing the exact source**, with a
+   system prompt that forbids using outside knowledge.
+
+```bash
+python assets/agentic_rag.py --index ./docs        # index a folder of .md/.txt files
+python assets/agentic_rag.py --ask "your question"  # query with the refusal gate active
+```
+
+## Step 8. Measure the refusal gate — do not skip this
+
+A refusal threshold you picked by eye is a guess. Calibrate it against **your** corpus:
+
+```bash
+python assets/agentic_rag.py --calibrate ./calibration.jsonl
+```
+
+Run at least 20 in-corpus questions and 20 out-of-corpus questions. Look at the distribution of
+the top reranker logit for each group. A healthy corpus shows a clean gap between the two; set
+the threshold in that gap. If the distributions overlap, the reranker cannot separate them for
+your data — that is a real finding, not a failure: tune the corpus or the retrieval before
+trusting the gate.
+
+> [!TIP]
+> Two questions that *look* out-of-corpus may actually be in it (or vice versa). Before
+> computing the gap, confirm each question's true membership against what you indexed — a single
+> mislabelled question can make a clean gap look like an overlap.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Embedding NIM returns HTTP 400 | Missing `input_type` | Add `"input_type": "passage"` (index) or `"query"` (search) — Step 6 |
+| Retrieval returns nothing / dimension error | Milvus collection dimension ≠ NIM dimension | Recreate the collection with the dimension the NIM reports (2048 by default) |
+| Reasoning model prepends `<think>…` monologue | Reasoning model emits its chain-of-thought | Strip everything up to and including `</think>` before returning the answer |
+| Answer is truncated or empty | Reasoning model spent the token budget inside `<think>` | Raise `max_tokens` (2000 is a safe start for this model) |
+| Model answers an out-of-corpus question anyway | Refusal gate not active (no reranker) or threshold too low | Confirm the reranker is reachable on `:8003`; re-run `--calibrate` |
+| `docker login nvcr.io` dumps a `wb-svc` error | AI Workbench credential helper | Remove `credsStore`/`credHelpers` from `~/.docker/config.json` |
+| NIM slow / OOM | Three NIMs + Milvus contending for memory | Serve fewer models at once, or flush cache: `sudo sh -c 'sync; echo 3 > /proc/sys/vm/drop_caches'` |
+
+## Next steps
+
+- **Add tenant isolation**: one Milvus collection per tenant, with the tenant as a hard
+  boundary — not a filter that can be forgotten.
+- **Add access control per chunk**: pass the requester's roles into every query; never default
+  to "see everything".
+- **Add jurisdiction checks**: tag each chunk with its data jurisdiction and refuse to send an
+  EU chunk to an endpoint outside the EU — evaluated before inference.
+- **Red-team the loop**: run the OWASP Agentic preset against your deployment; measure prompt
+  injection with n ≥ 20, not a single pass.
+- **Industrialise it**: the four items above, plus signed audit, licensing, and continuous
+  red-teaming, are what the [Tribu SDK](https://sdk.tribucorp.es) provides as a supported
+  library. This playbook is the honest, buildable core of that pattern.
+
+## License
+
+This playbook is contributed under the repository's Apache-2.0 license. The Tribu SDK itself is
+proprietary and is referenced here only as the production implementation of the pattern; no SDK
+source is included or required to complete this playbook.

--- a/nvidia/agentic-rag-provenance-refusal/assets/agentic_rag.py
+++ b/nvidia/agentic-rag-provenance-refusal/assets/agentic_rag.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Agentic RAG with provenance-enforced refusal on DGX Spark.
+
+Reference implementation for the playbook of the same name. Deliberately minimal: only
+`pymilvus` and `httpx`, no framework, no proprietary code. It demonstrates the one behaviour
+that matters — answer with a cited source or refuse, decided in code from the reranker score
+BEFORE the reasoning model is ever called.
+
+This is the honest, buildable core of the pattern that the Tribu SDK (https://sdk.tribucorp.es)
+industrialises. Everything here runs offline once the NIMs and Milvus are up.
+
+Usage:
+    python agentic_rag.py --index ./docs
+    python agentic_rag.py --ask "your question"
+    python agentic_rag.py --calibrate ./calibration.jsonl
+
+Environment (all with sensible DGX Spark defaults):
+    NIM_LLM_URL     reasoning NIM        (default http://localhost:8001)
+    NIM_EMBED_URL   embedding NIM        (default http://localhost:8002)
+    NIM_RERANK_URL  reranker NIM         (default http://localhost:8003)
+    MILVUS_URI      Milvus               (default http://localhost:19530)
+    REFUSAL_LOGIT   refusal threshold    (default -4.0 — CALIBRATE for your corpus, Step 8)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+import httpx
+from pymilvus import MilvusClient
+
+LLM_URL = os.environ.get("NIM_LLM_URL", "http://localhost:8001")
+EMBED_URL = os.environ.get("NIM_EMBED_URL", "http://localhost:8002")
+RERANK_URL = os.environ.get("NIM_RERANK_URL", "http://localhost:8003")
+MILVUS_URI = os.environ.get("MILVUS_URI", "http://localhost:19530")
+REFUSAL_LOGIT = float(os.environ.get("REFUSAL_LOGIT", "-4.0"))
+
+EMBED_MODEL = "nvidia/llama-nemotron-embed-1b-v2"
+RERANK_MODEL = "nvidia/llama-nemotron-rerank-vl-1b-v2"
+LLM_MODEL = "nvidia/nemotron-nano-9b-v2"
+COLLECTION = "playbook_rag"
+TIMEOUT = httpx.Timeout(120.0)  # real NIM inference is slower than a normal API
+
+SYSTEM_PROMPT = (
+    "You answer ONLY from the provided context, citing the exact source in brackets exactly as "
+    "it appears (e.g. [source: notes.md#2]). If the context is not enough to answer, say so "
+    "explicitly instead of inventing or using outside knowledge."
+)
+
+REFUSAL_TEXT = (
+    "I have no indexed source that answers this with confidence, so I will not invent an answer "
+    "without verifiable provenance."
+)
+
+
+def _embed(text: str, input_type: str) -> list[float]:
+    """The embed NIM is ASYMMETRIC: it returns HTTP 400 without input_type. 'passage' when
+    indexing, 'query' when searching. This is the #1 integration gotcha with this model."""
+    r = httpx.post(
+        f"{EMBED_URL}/v1/embeddings",
+        json={"model": EMBED_MODEL, "input": [text], "input_type": input_type},
+        timeout=TIMEOUT,
+    )
+    r.raise_for_status()
+    return r.json()["data"][0]["embedding"]
+
+
+def _rerank(question: str, passages: list[str]) -> list[tuple[int, float]]:
+    """Return (index, logit) sorted by descending relevance. The logit is the signal the
+    refusal gate uses — a well-separated corpus scores relevant passages clearly above
+    irrelevant ones. We keep the logits; most integrations throw them away and lose the gate."""
+    r = httpx.post(
+        f"{RERANK_URL}/v1/ranking",
+        json={
+            "model": RERANK_MODEL,
+            "query": {"text": question},
+            "passages": [{"text": p} for p in passages],
+        },
+        timeout=TIMEOUT,
+    )
+    r.raise_for_status()
+    ranked = sorted(r.json()["rankings"], key=lambda x: x["logit"], reverse=True)
+    return [(x["index"], x["logit"]) for x in ranked]
+
+
+def _complete(question: str, context: str) -> str:
+    r = httpx.post(
+        f"{LLM_URL}/v1/chat/completions",
+        json={
+            "model": LLM_MODEL,
+            "messages": [
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {"role": "user", "content": f"Context:\n{context}\n\nQuestion: {question}"},
+            ],
+            "max_tokens": 2000,  # reasoning models spend budget inside <think> before answering
+        },
+        timeout=TIMEOUT,
+    )
+    r.raise_for_status()
+    text = r.json()["choices"][0]["message"]["content"]
+    # Reasoning models (nemotron-nano included) emit their chain-of-thought before </think>.
+    marker = "</think>"
+    idx = text.rfind(marker)
+    return text[idx + len(marker):].lstrip() if idx != -1 else text
+
+
+def _client() -> MilvusClient:
+    return MilvusClient(uri=MILVUS_URI)
+
+
+def cmd_index(folder: str) -> int:
+    files = sorted(Path(folder).glob("**/*.md")) + sorted(Path(folder).glob("**/*.txt"))
+    if not files:
+        print(f"No .md/.txt files under {folder}", file=sys.stderr)
+        return 1
+
+    # Read the real dimension from the endpoint, fail-closed if the collection disagrees.
+    dim = len(_embed("dimension probe", "passage"))
+    print(f"Embedding dimension reported by the NIM: {dim} (the 2026 default is 2048).")
+
+    client = _client()
+    if client.has_collection(COLLECTION):
+        client.drop_collection(COLLECTION)
+    client.create_collection(collection_name=COLLECTION, dimension=dim, auto_id=True)
+
+    rows, n = [], 0
+    for f in files:
+        # One chunk per paragraph — deliberately simple; real chunking overlaps and contextualises.
+        for i, para in enumerate(p for p in f.read_text(encoding="utf-8").split("\n\n") if p.strip()):
+            rows.append({"vector": _embed(para, "passage"), "text": para.strip(),
+                         "source": f"{f.name}#{i}"})
+            n += 1
+    client.insert(collection_name=COLLECTION, data=rows)
+    print(f"Indexed {n} chunks from {len(files)} file(s) into '{COLLECTION}'.")
+    return 0
+
+
+def _answer(question: str, *, top_k: int = 5, candidates: int = 20) -> dict:
+    client = _client()
+    if not client.has_collection(COLLECTION):
+        return {"answer": REFUSAL_TEXT, "sources": [], "refused": True, "top_logit": None}
+
+    hits = client.search(
+        collection_name=COLLECTION,
+        data=[_embed(question, "query")],
+        limit=candidates,
+        output_fields=["text", "source"],
+    )[0]
+    if not hits:
+        return {"answer": REFUSAL_TEXT, "sources": [], "refused": True, "top_logit": None}
+
+    passages = [h["entity"]["text"] for h in hits]
+    ranked = _rerank(question, passages)
+    top_logit = ranked[0][1]
+
+    # THE GATE: refuse in code, from the score, BEFORE calling the reasoning model. A refusal
+    # never carries sources — a flag that says "refused" while returning 5 sources is a lie
+    # that any downstream consumer (evals, guardrails) will miscount.
+    if top_logit < REFUSAL_LOGIT:
+        return {"answer": REFUSAL_TEXT, "sources": [], "refused": True, "top_logit": top_logit}
+
+    chosen = [hits[i] for i, _ in ranked[:top_k]]
+    context = "\n\n".join(f"[source: {h['entity']['source']}]\n{h['entity']['text']}" for h in chosen)
+    answer = _complete(question, context)
+    return {
+        "answer": answer,
+        "sources": [h["entity"]["source"] for h in chosen],
+        "refused": False,
+        "top_logit": top_logit,
+    }
+
+
+def cmd_ask(question: str) -> int:
+    out = _answer(question)
+    print(json.dumps(out, ensure_ascii=False, indent=2))
+    return 0
+
+
+def cmd_calibrate(path: str) -> int:
+    """Each line: {"q": "...", "in_corpus": true|false}. Prints the logit distribution per group
+    so you can set REFUSAL_LOGIT in the gap between them (Step 8). n>=20 per group."""
+    inside, outside = [], []
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        rec = json.loads(line)
+        res = _answer(rec["q"])
+        (inside if rec["in_corpus"] else outside).append(res["top_logit"])
+
+    def stats(xs: list[float | None]) -> str:
+        vals = sorted(v for v in xs if v is not None)
+        if not vals:
+            return "n=0"
+        mid = vals[len(vals) // 2]
+        return f"n={len(vals)}  worst={vals[0]:.2f}  median={mid:.2f}  best={vals[-1]:.2f}"
+
+    print(f"in-corpus : {stats(inside)}")
+    print(f"out-corpus: {stats(outside)}")
+    ins = [v for v in inside if v is not None]
+    outs = [v for v in outside if v is not None]
+    if ins and outs:
+        gap = min(ins) - max(outs)
+        if gap > 0:
+            print(f"clean gap of {gap:.2f} logits — set REFUSAL_LOGIT near {min(ins) - gap / 2:.2f}")
+        else:
+            print("distributions OVERLAP — the reranker cannot separate them for this corpus. "
+                  "That is a real finding: tune the corpus or retrieval before trusting the gate.")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--index", metavar="FOLDER")
+    g.add_argument("--ask", metavar="QUESTION")
+    g.add_argument("--calibrate", metavar="JSONL")
+    a = ap.parse_args()
+    if a.index:
+        return cmd_index(a.index)
+    if a.ask:
+        return cmd_ask(a.ask)
+    return cmd_calibrate(a.calibrate)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

This playbook adds a fully on-prem **agentic RAG** workflow for DGX Spark whose defining behaviour is that the agent **answers with a cited source or refuses — it never fabricates**. The refusal decision is made *in code*, from the reranker's relevance score, **before** the reasoning model is ever called, and a refusal carries an empty source list by construction.

The stack is entirely local, no cloud APIs and no data leaving the machine:
- **Nemotron** (`nvidia/nemotron-nano-9b-v2`, served via NIM) for reasoning
- **NeMo Retriever** embeddings (asymmetric: `passage` at index time, `query` at search time) plus a **reranker NIM** for relevance scoring
- **Milvus** as the vector store, one collection per tenant

## What it teaches

- The **provenance-or-refusal** pattern: gate generation on the top reranker logit, so out-of-corpus questions are refused instead of answered with hallucinated text and mismatched citations.
- How to **calibrate the refusal threshold against your own corpus** rather than eyeballing it — the playbook walks through running in-corpus vs. out-of-corpus questions and reading the logit distribution to place the threshold in the gap (and treats an overlapping distribution as a real finding, not a failure).
- A note on the 2026 embedding-dimension default (**2048**, not 1024) and why the Milvus collection dimension must match or retrieval fails closed.

## Notes

- **Runs fully offline on the Spark** — all models served locally via NIM; nothing calls out.
- **Verified end-to-end against a real DGX Spark**, not just written against docs. The reference script (`assets/agentic_rag.py`) does indexing, querying with the refusal gate, and threshold calibration.
- The pattern shown here is the reference implementation of a component of the **Tribu SDK** (https://sdk.tribucorp.es); this playbook distills it into a self-contained, reproducible walkthrough.

Structure follows the repo convention: `nvidia/agentic-rag-provenance-refusal/` with `README.md` + `assets/`, and one line added to the root README's Available Playbooks list.
