### PR TITLE
fix: use dtype instead of deprecated torch_dtype

### DIFF
--- a/nvidia/station-kernel-dev-ft/assets/finetune_baseline.py
+++ b/nvidia/station-kernel-dev-ft/assets/finetune_baseline.py
@@ -13,6 +13,15 @@ Usage:
 import argparse
 import time
 import torch
+import transformers
+from packaging.version import Version
+
+def _dtype_kwargs(dtype):
+    """`dtype` keyword of `from_pretrained` exists since transformers 4.56 (PR #39782);
+    older versions use `torch_dtype`."""
+    if Version(transformers.__version__) >= Version("4.56"):
+        return {"dtype": dtype}
+    return {"torch_dtype": dtype}
 
 
 def main():
@@ -35,7 +44,7 @@ def main():
 
     model = AutoModelForCausalLM.from_pretrained(
         "meta-llama/Llama-3.1-8B",
-        torch_dtype=torch.bfloat16,
+        **_dtype_kwargs(torch.bfloat16),
         device_map="cuda",
     )
     model.train()


### PR DESCRIPTION
## Summary

`config.torch_dtype` and the `torch_dtype` keyword argument were deprecated in transformers 4.56 (PR #39782) and replaced by `dtype`. This PR updates the `AutoModelForCausalLM.from_pretrained` call in `nvidia/station-kernel-dev-ft/assets/finetune_baseline.py` (line 36) to select the keyword from the installed transformers version using `packaging.version`, so transformers < 4.56 keeps working.

## Changes

- `nvidia/station-kernel-dev-ft/assets/finetune_baseline.py`: add a `_dtype_kwargs` helper that returns `{"dtype": ...}` on transformers >= 4.56 and `{"torch_dtype": ...}` otherwise; the `from_pretrained` call passes it as `**_dtype_kwargs(torch.bfloat16)`.

## Test

- The modified file compiles (`python -m py_compile`).
- On transformers >= 4.56 the call uses `dtype` and emits no deprecation warning; on older versions it passes `torch_dtype` unchanged.

Fixes #113